### PR TITLE
feat: wait until running grpc server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 vendor
 coverage
 features/logs/*.log
+/.idea/

--- a/lib/nonnative/grpc_server.rb
+++ b/lib/nonnative/grpc_server.rb
@@ -2,13 +2,14 @@
 
 module Nonnative
   class GRPCServer < Nonnative::Server
-    def initialize(port)
+    def initialize(port, timeout)
       @server = GRPC::RpcServer.new
 
       server.add_http2_port("0.0.0.0:#{port}", :this_port_is_insecure)
+      server.wait_till_running(timeout)
       configure server
 
-      super port
+      super port, timeout
     end
 
     def configure(grpc)

--- a/lib/nonnative/http_server.rb
+++ b/lib/nonnative/http_server.rb
@@ -2,11 +2,11 @@
 
 module Nonnative
   class HTTPServer < Nonnative::Server
-    def initialize(port)
+    def initialize(port, timeout)
       Application.set :port, port
       configure Application
 
-      super port
+      super port, timeout
     end
 
     def configure(http)

--- a/lib/nonnative/pool.rb
+++ b/lib/nonnative/pool.rb
@@ -28,7 +28,7 @@ module Nonnative
 
     def servers
       @servers ||= configuration.servers.map do |d|
-        [d.klass.new(d.port), Nonnative::Port.new(d)]
+        [d.klass.new(d.port, d.timeout), Nonnative::Port.new(d)]
       end
     end
 

--- a/lib/nonnative/server.rb
+++ b/lib/nonnative/server.rb
@@ -2,8 +2,9 @@
 
 module Nonnative
   class Server < Thread
-    def initialize(port)
+    def initialize(port, timeout)
       @port = port
+      @timeout = timeout
       self.abort_on_exception = true
 
       super do
@@ -25,5 +26,6 @@ module Nonnative
     end
 
     attr_reader :port
+    attr_reader :timeout
   end
 end


### PR DESCRIPTION
To having stable nonnative GRPC server connection we have to wait until it running before handling any requests.