### PR TITLE
feat(cucumber): verify system start errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (1.58.2)
+    nonnative (1.59.0)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       cucumber (>= 7, < 8)
       get_process_mem (~> 0.2.1)
@@ -72,7 +72,6 @@ GEM
     grpc (1.45.0-universal-darwin)
       google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
-    grpc-tools (1.45.0)
     http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
@@ -190,7 +189,6 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.3)
   coveralls_reborn (~> 0.24.0)
-  grpc-tools (>= 1, < 2)
   nonnative!
   rubocop (~> 1.26)
   solargraph (~> 0.44.3)

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ With cucumber:
 
 ```cucumber
 Given I set the proxy for process 'process_1' to 'close_all'
-Then And I should reset the proxy for process 'process_1'
+Then I should reset the proxy for process 'process_1'
 ```
 
 ###### Servers
@@ -549,7 +549,7 @@ With cucumber:
 
 ```cucumber
 Given I set the proxy for server 'server_1' to 'close_all'
-Then And I should reset the proxy for server 'server_1'
+Then I should reset the proxy for server 'server_1'
 ```
 
 ###### Services
@@ -568,7 +568,7 @@ With cucumber:
 
 ```cucumber
 Given I set the proxy for service 'service_1' to 'close_all'
-Then And I should reset the proxy for service 'service_1'
+Then I should reset the proxy for service 'service_1'
 ```
 
 ### Go

--- a/features/benchmark.feature
+++ b/features/benchmark.feature
@@ -9,7 +9,7 @@ Feature: Benchmark
 
   Scenario: Stop nonnative within an adequate time
     Given I configure nonnative through configuration with processes
-    When I start nonnative
+    When I start the system
     Then stoping nonnative should happen within an adequate time
 
   @manual
@@ -19,5 +19,5 @@ Feature: Benchmark
 
   Scenario: Stop nonnative with a long stopping time server will error
     Given I configure nonnative programatially with a no stop server
-    When I start nonnative
+    When I start the system
     Then stopping nonnative should raise an error

--- a/features/benchmark.feature
+++ b/features/benchmark.feature
@@ -3,21 +3,21 @@ Feature: Benchmark
   Allows us to check that start and stop responds in adequate time
 
   @manual
-  Scenario: Start nonnative within an adequate time
-    When I configure nonnative through configuration with processes
-    Then starting nonnative should happen within an adequate time
+  Scenario: Start the system within an adequate time
+    When I configure the system through configuration with processes
+    Then starting the system should happen within an adequate time
 
-  Scenario: Stop nonnative within an adequate time
-    Given I configure nonnative through configuration with processes
+  Scenario: Stop the system within an adequate time
+    Given I configure the system through configuration with processes
     When I start the system
-    Then stoping nonnative should happen within an adequate time
+    Then stoping the system should happen within an adequate time
 
   @manual
   Scenario: Start nonnative with a long start up time server will error
-    When I configure nonnative programatially with a no op server
-    Then starting nonnative should raise an error
+    When I configure the system programatially with a no op server
+    Then starting the system should raise an error
 
   Scenario: Stop nonnative with a long stopping time server will error
-    Given I configure nonnative programatially with a no stop server
+    Given I configure the system programatially with a no stop server
     When I start the system
-    Then stopping nonnative should raise an error
+    Then stopping the system should raise an error

--- a/features/processes.feature
+++ b/features/processes.feature
@@ -4,7 +4,7 @@ Feature: Processes
   Allows us to start a process and use a client to get a response.
 
   Scenario: Successfully starting of processes
-    Given I configure nonnative programatically with processes
+    Given I configure the system programatically with processes
     And I start the system
     When I send "test" with the TCP client to the processes
     Then I should receive a TCP "test" response
@@ -12,7 +12,7 @@ Feature: Processes
     And the process 'start_1' should consume less than '30mb' of memory
 
   Scenario: Successfully starting of processes and closing connections
-    Given I configure nonnative programatically with processes
+    Given I configure the system programatically with processes
     And I start the system
     And I set the proxy for process 'start_1' to 'close_all'
     When I send "test" with the TCP client 'start_1' to the processe
@@ -20,7 +20,7 @@ Feature: Processes
     And I should reset the proxy for process 'start_1'
 
   Scenario: Successfully starting of processes and getting invalid data
-    Given I configure nonnative programatically with processes
+    Given I configure the system programatically with processes
     And I start the system
     And I set the proxy for process 'start_1' to 'invalid_data'
     When I send "test" with the TCP client 'start_1' to the processe
@@ -28,7 +28,7 @@ Feature: Processes
     And I should reset the proxy for process 'start_1'
 
   Scenario: Proxy for process is not found
-    Given I configure nonnative programatically with processes
+    Given I configure the system programatically with processes
     And I start the system
     When I try to find the proxy for process 'non_existent'
     Then I should get a proxy not found error

--- a/features/processes.feature
+++ b/features/processes.feature
@@ -5,7 +5,7 @@ Feature: Processes
 
   Scenario: Successfully starting of processes
     Given I configure nonnative programatically with processes
-    And I start nonnative
+    And I start the system
     When I send "test" with the TCP client to the processes
     Then I should receive a TCP "test" response
     And I should see a log entry of "test" in the file "features/logs/12_321.log"
@@ -13,7 +13,7 @@ Feature: Processes
 
   Scenario: Successfully starting of processes and closing connections
     Given I configure nonnative programatically with processes
-    And I start nonnative
+    And I start the system
     And I set the proxy for process 'start_1' to 'close_all'
     When I send "test" with the TCP client 'start_1' to the processe
     Then I should receive a connection error for client response with TCP
@@ -21,7 +21,7 @@ Feature: Processes
 
   Scenario: Successfully starting of processes and getting invalid data
     Given I configure nonnative programatically with processes
-    And I start nonnative
+    And I start the system
     And I set the proxy for process 'start_1' to 'invalid_data'
     When I send "test" with the TCP client 'start_1' to the processe
     Then I should receive a invalid data that is not "test" for client response with TCP
@@ -29,6 +29,6 @@ Feature: Processes
 
   Scenario: Proxy for process is not found
     Given I configure nonnative programatically with processes
-    And I start nonnative
+    And I start the system
     When I try to find the proxy for process 'non_existent'
     Then I should get a proxy not found error

--- a/features/servers.feature
+++ b/features/servers.feature
@@ -4,103 +4,103 @@ Feature: Servers
   Allows us to start a server and use a client to get a response.
 
   Scenario: Successfully starting of TCP servers programatically
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I send a message with the tcp client to the servers
     Then I should receive a TCP "Hello World!" response
 
   Scenario: Successfully starting of TCP servers through configuration
-    Given I configure nonnative through configuration with servers
+    Given I configure the system through configuration with servers
     And I start the system
     When I send a message with the tcp client to the servers
     Then I should receive a TCP "Hello World!" response
 
   Scenario: Successfully starting of HTTP servers programatically
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I send a message with the http client to the servers
     Then I should receive a http "Hello World!" response
 
   Scenario: Successfully starting of HTTP servers programatically with not found message
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I send a not found message with the http client to the servers
     Then I should receive a http not found response
 
   Scenario: Successfully starting of gRPC servers programatically
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I send a message with the grpc client to the servers
     Then I should receive a grpc "Hello World!" response
 
   Scenario: Successfully starting of HTTP servers programatically and getting health
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I send a "health" request
     Then I should receive a successful "health" response
 
   Scenario: Successfully starting of HTTP servers programatically and getting liveness
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I send a "liveness" request
     Then I should receive a successful "liveness" response
 
   Scenario: Successfully starting of HTTP servers programatically and getting readiness
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I send a "readiness" request
     Then I should receive a successful "readiness" response
 
   Scenario: Successfully starting of HTTP servers programatically and getting metrics
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I send a "metrics" request
     Then I should receive a successful "metrics" response
 
   Scenario: Successfully starting of HTTP servers programatically and closing connections while getting metrics
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I set the proxy for server 'http_server_1' to 'close_all'
     Then I should receive a connection error for metrics response with HTTP
     And I should reset the proxy for server 'http_server_1'
 
   Scenario: Successfully starting of HTTP servers programatically and delaying connections while getting hello
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I set the proxy for server 'http_server_1' to 'delay'
     Then I should receive a delay error for hello response with HTTP
     And I should reset the proxy for server 'http_server_1'
 
   Scenario: Successfully starting of HTTP servers programatically and sending invalid data while getting hello
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I set the proxy for server 'http_server_1' to 'invalid_data'
     Then I should receive a invalid data error for hello response with HTTP
     And I should reset the proxy for server 'http_server_1'
 
   Scenario: Successfully starting of gRPC servers programatically and closing connections while getting greeted
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I set the proxy for server 'grpc_server_1' to 'close_all'
     Then I should receive a connection error for being greeted with gRPC
     And I should reset the proxy for server 'grpc_server_1'
 
   Scenario: Successfully starting of gRCP servers programatically and delaying connections while getting greeted
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I set the proxy for server 'grpc_server_1' to 'delay'
     Then I should receive a delay error for being greeted with gRPC
     And I should reset the proxy for server 'grpc_server_1'
 
   Scenario: Successfully starting of gRPC servers programatically and sending invalid data while getting greeted
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I set the proxy for server 'grpc_server_1' to 'invalid_data'
     Then I should receive a invalid data error for being greeted with gRPC
     And I should reset the proxy for server 'grpc_server_1'
 
   Scenario: Proxy for server is not found
-    Given I configure nonnative programatically with servers
+    Given I configure the system programatically with servers
     And I start the system
     When I try to find the proxy for server 'non_existent'
     Then I should get a proxy not found error

--- a/features/servers.feature
+++ b/features/servers.feature
@@ -5,102 +5,102 @@ Feature: Servers
 
   Scenario: Successfully starting of TCP servers programatically
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I send a message with the tcp client to the servers
     Then I should receive a TCP "Hello World!" response
 
   Scenario: Successfully starting of TCP servers through configuration
     Given I configure nonnative through configuration with servers
-    And I start nonnative
+    And I start the system
     When I send a message with the tcp client to the servers
     Then I should receive a TCP "Hello World!" response
 
   Scenario: Successfully starting of HTTP servers programatically
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I send a message with the http client to the servers
     Then I should receive a http "Hello World!" response
 
   Scenario: Successfully starting of HTTP servers programatically with not found message
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I send a not found message with the http client to the servers
     Then I should receive a http not found response
 
   Scenario: Successfully starting of gRPC servers programatically
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I send a message with the grpc client to the servers
     Then I should receive a grpc "Hello World!" response
 
   Scenario: Successfully starting of HTTP servers programatically and getting health
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I send a "health" request
     Then I should receive a successful "health" response
 
   Scenario: Successfully starting of HTTP servers programatically and getting liveness
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I send a "liveness" request
     Then I should receive a successful "liveness" response
 
   Scenario: Successfully starting of HTTP servers programatically and getting readiness
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I send a "readiness" request
     Then I should receive a successful "readiness" response
 
   Scenario: Successfully starting of HTTP servers programatically and getting metrics
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I send a "metrics" request
     Then I should receive a successful "metrics" response
 
   Scenario: Successfully starting of HTTP servers programatically and closing connections while getting metrics
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I set the proxy for server 'http_server_1' to 'close_all'
     Then I should receive a connection error for metrics response with HTTP
     And I should reset the proxy for server 'http_server_1'
 
   Scenario: Successfully starting of HTTP servers programatically and delaying connections while getting hello
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I set the proxy for server 'http_server_1' to 'delay'
     Then I should receive a delay error for hello response with HTTP
     And I should reset the proxy for server 'http_server_1'
 
   Scenario: Successfully starting of HTTP servers programatically and sending invalid data while getting hello
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I set the proxy for server 'http_server_1' to 'invalid_data'
     Then I should receive a invalid data error for hello response with HTTP
     And I should reset the proxy for server 'http_server_1'
 
   Scenario: Successfully starting of gRPC servers programatically and closing connections while getting greeted
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I set the proxy for server 'grpc_server_1' to 'close_all'
     Then I should receive a connection error for being greeted with gRPC
     And I should reset the proxy for server 'grpc_server_1'
 
   Scenario: Successfully starting of gRCP servers programatically and delaying connections while getting greeted
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I set the proxy for server 'grpc_server_1' to 'delay'
     Then I should receive a delay error for being greeted with gRPC
     And I should reset the proxy for server 'grpc_server_1'
 
   Scenario: Successfully starting of gRPC servers programatically and sending invalid data while getting greeted
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I set the proxy for server 'grpc_server_1' to 'invalid_data'
     Then I should receive a invalid data error for being greeted with gRPC
     And I should reset the proxy for server 'grpc_server_1'
 
   Scenario: Proxy for server is not found
     Given I configure nonnative programatically with servers
-    And I start nonnative
+    And I start the system
     When I try to find the proxy for server 'non_existent'
     Then I should get a proxy not found error

--- a/features/services.feature
+++ b/features/services.feature
@@ -4,19 +4,19 @@ Feature: Services
   Allows us to use an external service and use a client to get a response.
 
   Scenario: Successfully using of services programatically
-    Given I configure nonnative programatically with services
+    Given I configure the system programatically with services
     And I start the system
     When I connect to the service
     Then I should have a succesful connection
 
   Scenario: Successfully using of services through configuration
-    Given I configure nonnative through configuration with services
+    Given I configure the system through configuration with services
     And I start the system
     When I connect to the service
     Then I should have a succesful connection
 
   Scenario: Successfully using of services and closing connections
-    Given I configure nonnative programatically with services
+    Given I configure the system programatically with services
     And I start the system
     And I set the proxy for service 'service_1' to 'close_all'
     When I connect to the service
@@ -24,7 +24,7 @@ Feature: Services
     And I should reset the proxy for service 'service_1'
 
   Scenario: Proxy for service is not found
-    Given I configure nonnative programatically with services
+    Given I configure the system programatically with services
     And I start the system
     When I try to find the proxy for service 'non_existent'
     Then I should get a proxy not found error

--- a/features/services.feature
+++ b/features/services.feature
@@ -5,19 +5,19 @@ Feature: Services
 
   Scenario: Successfully using of services programatically
     Given I configure nonnative programatically with services
-    And I start nonnative
+    And I start the system
     When I connect to the service
     Then I should have a succesful connection
 
   Scenario: Successfully using of services through configuration
     Given I configure nonnative through configuration with services
-    And I start nonnative
+    And I start the system
     When I connect to the service
     Then I should have a succesful connection
 
   Scenario: Successfully using of services and closing connections
     Given I configure nonnative programatically with services
-    And I start nonnative
+    And I start the system
     And I set the proxy for service 'service_1' to 'close_all'
     When I connect to the service
     Then I should receive a connection error from the service
@@ -25,6 +25,6 @@ Feature: Services
 
   Scenario: Proxy for service is not found
     Given I configure nonnative programatically with services
-    And I start nonnative
+    And I start the system
     When I try to find the proxy for service 'non_existent'
     Then I should get a proxy not found error

--- a/features/step_definitions/benchmark_steps.rb
+++ b/features/step_definitions/benchmark_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-When('I configure nonnative programatially with a no op server') do
+When('I configure the system programatially with a no op server') do
   Nonnative.configure do |config|
     config.strategy = :manual
 
@@ -12,7 +12,7 @@ When('I configure nonnative programatially with a no op server') do
   end
 end
 
-When('I configure nonnative programatially with a no stop server') do
+When('I configure the system programatially with a no stop server') do
   Nonnative.configure do |config|
     config.strategy = :manual
 
@@ -24,18 +24,10 @@ When('I configure nonnative programatially with a no stop server') do
   end
 end
 
-Then('starting nonnative should happen within an adequate time') do
+Then('starting the system should happen within an adequate time') do
   expect { Nonnative.start }.to perform_under(2, warmup: 0).sec
 end
 
-Then('stoping nonnative should happen within an adequate time') do
+Then('stoping the system should happen within an adequate time') do
   expect { Nonnative.stop }.to perform_under(2, warmup: 0).sec
-end
-
-Then('starting nonnative should raise an error') do
-  expect { Nonnative.start }.to raise_error(Nonnative::StartError)
-end
-
-Then('stopping nonnative should raise an error') do
-  expect { Nonnative.stop }.to raise_error(Nonnative::StopError)
 end

--- a/features/step_definitions/processes_steps.rb
+++ b/features/step_definitions/processes_steps.rb
@@ -43,10 +43,6 @@ Given('I configure nonnative through configuration with processes') do
   end
 end
 
-Given('I start nonnative') do
-  Nonnative.start
-end
-
 When('I send {string} with the TCP client to the processes') do |message|
   @responses = [
     Nonnative::Features::TCPClient.new(12_321).request(message),

--- a/features/step_definitions/processes_steps.rb
+++ b/features/step_definitions/processes_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Given('I configure nonnative programatically with processes') do
+Given('I configure the system programatically with processes') do
   Nonnative.configure do |config|
     config.strategy = :manual
 
@@ -37,7 +37,7 @@ Given('I configure nonnative programatically with processes') do
   end
 end
 
-Given('I configure nonnative through configuration with processes') do
+Given('I configure the system through configuration with processes') do
   Nonnative.configure do |config|
     config.load_file('features/configs/processes.yml')
   end

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Given('I configure nonnative programatically with servers') do
+Given('I configure the system programatically with servers') do
   Nonnative.configure do |config|
     config.strategy = :manual
 
@@ -88,7 +88,7 @@ Given('I configure nonnative programatically with servers') do
   end
 end
 
-Given('I configure nonnative through configuration with servers') do
+Given('I configure the system through configuration with servers') do
   Nonnative.configure do |config|
     config.load_file('features/configs/servers.yml')
   end

--- a/features/step_definitions/services_steps.rb
+++ b/features/step_definitions/services_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Given('I configure nonnative programatically with services') do
+Given('I configure the system programatically with services') do
   Nonnative.configure do |config|
     config.strategy = :manual
 
@@ -21,7 +21,7 @@ Given('I configure nonnative programatically with services') do
   end
 end
 
-Given('I configure nonnative through configuration with services') do
+Given('I configure the system through configuration with services') do
   Nonnative.configure do |config|
     config.load_file('features/configs/services.yml')
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,9 +13,6 @@ SimpleCov.start do
 end
 
 require 'nonnative'
-require 'rspec-benchmark'
-
-World(RSpec::Benchmark::Matchers)
 
 Before do
   Nonnative.clear

--- a/features/support/manual.rb
+++ b/features/support/manual.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-After('@manual') do
-  Nonnative.stop
-end

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -14,6 +14,7 @@ require 'puma/server'
 require 'concurrent'
 require 'cucumber'
 require 'get_process_mem'
+require 'rspec-benchmark'
 
 require 'nonnative/version'
 require 'nonnative/error'

--- a/lib/nonnative/cucumber.rb
+++ b/lib/nonnative/cucumber.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+After('@manual') do
+  Nonnative.stop
+end
+
 Given('I set the proxy for process {string} to {string}') do |name, operation|
   process = Nonnative.pool.process_by_name(name)
   process.proxy.send(operation)

--- a/lib/nonnative/cucumber.rb
+++ b/lib/nonnative/cucumber.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+World(RSpec::Benchmark::Matchers)
+
 After('@manual') do
   Nonnative.stop
 end

--- a/lib/nonnative/cucumber.rb
+++ b/lib/nonnative/cucumber.rb
@@ -15,6 +15,10 @@ Given('I set the proxy for service {string} to {string}') do |name, operation|
   service.proxy.send(operation)
 end
 
+Given('I start the system') do
+  Nonnative.start
+end
+
 Then('I should reset the proxy for process {string}') do |name|
   process = Nonnative.pool.process_by_name(name)
   process.proxy.reset

--- a/lib/nonnative/cucumber.rb
+++ b/lib/nonnative/cucumber.rb
@@ -46,3 +46,11 @@ Then('the process {string} should consume less than {string} of memory') do |nam
 
   expect(actual).to be < size
 end
+
+Then('starting the system should raise an error') do
+  expect { Nonnative.start }.to raise_error(Nonnative::StartError)
+end
+
+Then('stopping the system should raise an error') do
+  expect { Nonnative.stop }.to raise_error(Nonnative::StopError)
+end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nonnative
-  VERSION = '1.58.2'
+  VERSION = '1.59.0'
 end

--- a/nonnative.gemspec
+++ b/nonnative.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.3'
   spec.add_development_dependency 'coveralls_reborn', '~> 0.24.0'
-  spec.add_development_dependency 'grpc-tools', ['>= 1', '< 2']
   spec.add_development_dependency 'rubocop', '~> 1.26'
   spec.add_development_dependency 'solargraph', '~> 0.44.3'
 end


### PR DESCRIPTION
Here are the list of changes:
- Allow to verify that the system did not start correctly.
- Move some common cucumber hooks.
- Allow to start the system through cucumber.
- Remove grpc-tools.
- Fix the docs.