### PR TITLE
feat: move dev deps to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in nonnative.gemspec
 gemspec
+
+gem 'bundler'
+gem 'coveralls_reborn'
+gem 'rubocop'
+gem 'solargraph'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
       mime-types (~> 3.4, >= 3.4.1)
       multi_test (~> 1.1, >= 1.1.0)
       sys-uname (~> 1.2, >= 1.2.2)
-    cucumber-ci-environment (9.1.0)
+    cucumber-ci-environment (9.2.0)
     cucumber-core (11.0.0)
       cucumber-gherkin (~> 23.0, >= 23.0.1)
       cucumber-messages (~> 18.0, >= 18.0.0)
@@ -60,8 +60,8 @@ GEM
     ffi (1.15.5)
     get_process_mem (0.2.7)
       ffi (~> 1.0)
-    google-protobuf (3.23.0-x86_64-darwin)
-    google-protobuf (3.23.0-x86_64-linux)
+    google-protobuf (3.23.1-x86_64-darwin)
+    google-protobuf (3.23.1-x86_64-linux)
     googleapis-common-protos-types (1.6.0)
       google-protobuf (~> 3.14)
     grpc (1.54.2-x86_64-darwin)
@@ -81,23 +81,23 @@ GEM
       kramdown (~> 2.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0218.1)
     multi_test (1.1.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
     nio4r (2.5.9)
-    nokogiri (1.14.3-x86_64-darwin)
+    nokogiri (1.15.0-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.3-x86_64-linux)
+    nokogiri (1.15.0-x86_64-linux)
       racc (~> 1.4)
-    parallel (1.22.1)
-    parser (3.2.2.0)
+    parallel (1.23.0)
+    parser (3.2.2.1)
       ast (~> 2.4.1)
     puma (6.2.2)
       nio4r (~> 2.0)
     racc (1.6.2)
-    rack (2.2.6.4)
+    rack (2.2.7)
     rack-protection (3.0.6)
       rack
     rainbow (3.1.1)
@@ -120,16 +120,16 @@ GEM
       benchmark-perf (~> 0.6)
       benchmark-trend (~> 0.4)
       rspec (>= 3.0)
-    rspec-core (3.12.0)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.3)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.50.2)
+    rubocop (1.51.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
@@ -139,7 +139,7 @@ GEM
       rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.0)
+    rubocop-ast (1.28.1)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
@@ -171,11 +171,11 @@ GEM
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
     sync (0.5.0)
-    sys-uname (1.2.2)
+    sys-uname (1.2.3)
       ffi (~> 1.1)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    thor (1.2.1)
+    thor (1.2.2)
     tilt (2.1.0)
     tins (1.32.1)
       sync
@@ -183,18 +183,18 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
-    yard (0.9.32)
+    yard (0.9.34)
 
 PLATFORMS
   x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
-  bundler (~> 2.3)
-  coveralls_reborn (~> 0.27.0)
+  bundler
+  coveralls_reborn
   nonnative!
-  rubocop (~> 1.30)
-  solargraph (~> 0.49.0)
+  rubocop
+  solargraph
 
 BUNDLED WITH
    2.3.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (1.68.0)
+    nonnative (1.69.0)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       cucumber (>= 7, < 9)
       get_process_mem (~> 0.2.1)
@@ -61,13 +61,9 @@ GEM
     get_process_mem (0.2.7)
       ffi (~> 1.0)
     google-protobuf (3.23.1-x86_64-darwin)
-    google-protobuf (3.23.1-x86_64-linux)
     googleapis-common-protos-types (1.6.0)
       google-protobuf (~> 3.14)
     grpc (1.54.2-x86_64-darwin)
-      google-protobuf (~> 3.21)
-      googleapis-common-protos-types (~> 1.0)
-    grpc (1.54.2-x86_64-linux)
       google-protobuf (~> 3.21)
       googleapis-common-protos-types (~> 1.0)
     http-accept (1.7.0)

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nonnative
-  VERSION = '1.68.0'
+  VERSION = '1.69.0'
 end

--- a/nonnative.gemspec
+++ b/nonnative.gemspec
@@ -33,9 +33,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rspec-benchmark', '~> 0.6.0'
   spec.add_dependency 'rspec-expectations', '~> 3.9', '>= 3.9.2'
   spec.add_dependency 'sinatra', '>= 2.0.8.1', '< 4'
-
-  spec.add_development_dependency 'bundler', '~> 2.3'
-  spec.add_development_dependency 'coveralls_reborn', '~> 0.27.0'
-  spec.add_development_dependency 'rubocop', '~> 1.30'
-  spec.add_development_dependency 'solargraph', '~> 0.49.0'
 end


### PR DESCRIPTION
Move the deps to Gemfile as described by https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecdevelopmentdependencies