### PR TITLE
feat(invalid_data): a delimiter-only response still needs one byte we can corrupt without removing the line ending

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (2.11.0)
+    nonnative (2.12.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 11)

--- a/lib/nonnative/invalid_data_socket_pair.rb
+++ b/lib/nonnative/invalid_data_socket_pair.rb
@@ -3,8 +3,8 @@
 module Nonnative
   # Socket-pair variant used by the fault-injection proxy to simulate corrupted/incoherent traffic.
   #
-  # When active, data written to the upstream socket is corrupted by shuffling the payload bytes
-  # before forwarding.
+  # When active, client requests still pass through unchanged, but responses flowing back from the
+  # upstream socket are corrupted before they reach the client.
   #
   # This behavior is enabled by calling {Nonnative::FaultInjectionProxy#invalid_data}.
   #
@@ -12,16 +12,28 @@ module Nonnative
   # @see Nonnative::SocketPairFactory
   # @see Nonnative::SocketPair
   class InvalidDataSocketPair < SocketPair
-    # Writes corrupted data to the socket by shuffling bytes.
+    LINE_DELIMITERS = ["\r\n", "\n", "\r"].freeze
+
+    # Track the accepted client socket so we can corrupt only the response path.
+    def connect(local_socket)
+      @local_socket = local_socket
+
+      super
+    ensure
+      @local_socket = nil
+    end
+
+    # Writes corrupted data to the socket by mutating payload bytes.
     #
-    # The payload must always change, otherwise short or repetitive inputs such as "test" can
-    # occasionally pass through unchanged and make fault-injection scenarios flaky.
+    # Client requests are forwarded unchanged so the upstream service can still parse them.
+    # Responses flowing back to the client are corrupted in-place, which keeps line-based clients
+    # from hanging while ensuring echoed data does not come back unchanged.
     #
     # @param socket [IO] the socket to write to
     # @param data [String] the original payload
     # @return [Integer] number of bytes written
     def write(socket, data)
-      Nonnative.logger.info "shuffling socket data '#{socket.inspect}' for 'invalid_data' pair"
+      return super unless socket.equal?(@local_socket)
 
       super(socket, corrupt(data))
     end
@@ -29,40 +41,18 @@ module Nonnative
     private
 
     def corrupt(data)
-      payload, delimiter = split_trailing_delimiter(data)
-      return "\0#{delimiter}" if payload.empty?
+      # Preserve a final line ending so line-oriented clients still finish their reads.
+      delimiter = LINE_DELIMITERS.find { |candidate| data.end_with?(candidate) } || ''
+      payload = data.delete_suffix(delimiter)
 
-      "#{corrupt_payload(payload)}#{delimiter}"
-    end
+      # A delimiter-only response still needs one byte we can corrupt without losing the terminator.
+      payload = "\0" if payload.empty?
 
-    def split_trailing_delimiter(data)
-      index = trailing_delimiter_start(data)
-      payload = data.byteslice(0, index)
-      delimiter = data.byteslice(index, data.bytesize - index) || ''
+      # Flip the first byte so the payload is definitely wrong without mangling the whole
+      # response structure and turning an invalid response into a timeout.
+      payload.setbyte(0, payload.getbyte(0).zero? ? 1 : 0)
 
-      [payload, delimiter]
-    end
-
-    def trailing_delimiter_start(data)
-      index = data.bytesize
-
-      while index.positive?
-        byte = data.getbyte(index - 1)
-        break unless [10, 13].include?(byte)
-
-        index -= 1
-      end
-
-      index
-    end
-
-    def corrupt_payload(payload)
-      bytes = payload.bytes
-      corrupted = bytes.shuffle
-      return corrupted.pack('C*') unless corrupted == bytes
-
-      corrupted[0] = (corrupted[0] + 1) % 256
-      corrupted.pack('C*')
+      "#{payload}#{delimiter}"
     end
   end
 end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '2.11.0'
+  VERSION = '2.12.0'
 end


### PR DESCRIPTION
## What
- fixed the `invalid_data` fault-injection behavior so it corrupts only responses flowing back to the client instead of both directions
- preserved trailing line endings for line-based TCP fixtures so invalid-data scenarios do not hang on `gets`
- simplified the corruption logic so it no longer depends on shuffling or regex-based delimiter handling
- added a couple of targeted comments in `lib/nonnative/invalid_data_socket_pair.rb` to explain the response-only corruption and delimiter-only fallback

## Why
- prevents the TCP invalid-data process scenario from intermittently returning the original `"test"` value
- avoids hangs in line-oriented TCP clients when corrupted data would otherwise lose its terminator
- keeps HTTP invalid-data failures surfacing as invalid responses instead of request-side breakage or read timeouts
- makes the implementation easier to reason about than the earlier shuffle-based approach

## Testing
- ran `make lint`
- ran `bundle exec cucumber --format progress --publish-quiet features/processes.feature:46`
- ran `bundle exec cucumber --format progress --publish-quiet features/server_fault_injection.feature`