### PR TITLE
fix(fault_injection): proxy shutdown and wiring docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (2.13.0)
+    nonnative (2.13.1)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -681,6 +681,8 @@ services:
 
 The `fault_injection` proxy allows you to simulate failures by injecting them. We currently support the following:
 
+Clients connect to the runner `host`/`port`, while the proxy forwards traffic to nested `proxy.host`/`proxy.port`.
+
 - `close_all` - Closes the socket as soon as it connects.
 - `delay` - This delays the communication between the connection. Default is 2 secs can be configured through options.
 - `invalid_data` - This takes the input and rearranges it to produce invalid data.

--- a/features/lifecycle.feature
+++ b/features/lifecycle.feature
@@ -54,6 +54,16 @@ Feature: Lifecycle
     Then the logger should be recreated for the new configuration
     And the observability client should be recreated for the new configuration
 
+  @service
+  Scenario: Stopping a service runner closes active proxy connections
+    Given I configure the system programmatically with services
+    And I start the system
+    When I connect to the service
+    And I send "ping" to the service
+    And I stop the service runner "service_1"
+    And I receive data from the service
+    Then I should receive a connection error from the service
+
   Scenario: Requiring nonnative outside Cucumber succeeds
     When I require "nonnative" in a subprocess
     Then the subprocess should exit successfully

--- a/features/step_definitions/services_steps.rb
+++ b/features/step_definitions/services_steps.rb
@@ -12,6 +12,14 @@ When('I connect to the service') do
   @service = Nonnative::Features::Service.new(configured_service('service_1').port)
 end
 
+When('I send {string} to the service') do |message|
+  @service.write(message)
+end
+
+When('I stop the service runner {string}') do |name|
+  Nonnative.pool.service_by_name(name).stop
+end
+
 When('I receive data from the service') do
   @service_response = @service.receive
 end
@@ -21,9 +29,14 @@ When('I try to find the proxy for service {string}') do |name|
 end
 
 Then('I should receive a connection error from the service') do
-  expect(@service_response).to be_nil
+  expect(@service_response).not_to be_a(String)
+  expect(connection_error?(@service_response)).to be(true)
 end
 
 Then('I should have a successful connection') do
   expect(@service).not_to be_closed
+end
+
+def connection_error?(response)
+  response.nil? || response.is_a?(IOError) || response.is_a?(SystemCallError)
 end

--- a/features/support/service.rb
+++ b/features/support/service.rb
@@ -24,6 +24,10 @@ module Nonnative
       rescue StandardError => e
         e
       end
+
+      def write(message)
+        @socket.puts(message)
+      end
     end
   end
 end

--- a/lib/nonnative/fault_injection_proxy.rb
+++ b/lib/nonnative/fault_injection_proxy.rb
@@ -18,15 +18,15 @@ module Nonnative
   #
   # ## Wiring
   #
-  # When enabled, your test/client should typically connect to {#host}:{#port} (the proxy endpoint),
-  # and the proxy will connect onward to the underlying service.
+  # When enabled, your test/client should connect to the runner `host` / `port` (the proxy endpoint),
+  # and the proxy will forward traffic to the upstream target exposed by {#host}:{#port}.
   #
   # ## Configuration
   #
   # The proxy is configured via the runner’s `proxy` hash:
   #
   # - `kind`: `"fault_injection"`
-  # - `host` / `port`: where the proxy should be reached by clients (exposed via {#host}/{#port})
+  # - `host` / `port`: upstream target behind the proxy (exposed via {#host}/{#port})
   # - `log`: file path used by this proxy’s internal logger
   # - `wait`: sleep interval (seconds) applied after state changes
   # - `options`:
@@ -35,6 +35,21 @@ module Nonnative
   # @see Nonnative::Proxy
   # @see Nonnative::SocketPairFactory
   class FaultInjectionProxy < Nonnative::Proxy
+    class Connection
+      attr_accessor :pair, :thread
+      attr_reader :socket
+
+      def initialize(socket)
+        @socket = socket
+      end
+
+      def close
+        pair&.close
+        socket.close unless socket.closed?
+        thread&.terminate
+      end
+    end
+
     # @param service [Nonnative::ConfigurationRunner] runner configuration with proxy settings
     def initialize(service)
       @connections = Concurrent::Hash.new
@@ -48,7 +63,7 @@ module Nonnative
     # Starts the proxy accept loop in a background thread.
     #
     # This binds a TCP server on the underlying runner’s `service.host` / `service.port`.
-    # Clients should connect to {#host}:{#port}.
+    # Clients connect to that runner endpoint, while upstream traffic is forwarded to {#host}:{#port}.
     #
     # @return [void]
     def start
@@ -58,12 +73,21 @@ module Nonnative
       Nonnative.logger.info "started with host '#{service.host}' and port '#{service.port}' for proxy 'fault_injection'"
     end
 
-    # Stops the proxy and closes its listening socket.
+    # Stops the proxy, closes active connections, and closes its listening socket.
     #
     # @return [void]
     def stop
-      thread&.terminate
-      tcp_server&.close
+      mutex.synchronize do
+        close_connections
+      end
+
+      server = @tcp_server
+      @tcp_server = nil
+      server&.close
+
+      listener_thread = @thread
+      @thread = nil
+      listener_thread&.join
 
       Nonnative.logger.info "stopped with host '#{service.host}' and port '#{service.port}' for proxy 'fault_injection'"
     end
@@ -98,14 +122,14 @@ module Nonnative
       apply_state :none
     end
 
-    # Returns the host clients should connect to when using this proxy.
+    # Returns the upstream host behind this proxy.
     #
     # @return [String]
     def host
       service.proxy.host
     end
 
-    # Returns the port clients should connect to when using this proxy.
+    # Returns the upstream port behind this proxy.
     #
     # @return [Integer]
     def port
@@ -118,14 +142,16 @@ module Nonnative
 
     def perform_start
       loop do
-        thread = Thread.start(tcp_server.accept) do |local_socket|
-          id = Thread.current.object_id
-
-          accept_connection id, local_socket
+        local_socket = tcp_server.accept
+        id = local_socket.object_id
+        register_connection(id, local_socket)
+        connection_thread = Thread.start(local_socket) do |accepted_socket|
+          accept_connection id, accepted_socket
         end
-
-        connections[thread.object_id] = thread
+        attach_connection_thread(id, connection_thread)
       end
+    rescue IOError, Errno::EBADF
+      nil
     end
 
     def accept_connection(id, socket)
@@ -144,6 +170,7 @@ module Nonnative
       Nonnative.logger.info "connecting for '#{id}' with socket '#{socket.inspect}' and state '#{state}' for proxy 'fault_injection'"
 
       pair = SocketPairFactory.create(state, service.proxy)
+      attach_connection_pair(id, pair)
       pair.connect(socket)
     rescue StandardError => e
       socket.close
@@ -152,12 +179,10 @@ module Nonnative
     end
 
     def close_connections
-      connections.each do |id, thread|
-        Nonnative.logger.info "closing connection for '#{id}' for proxy 'fault_injection'"
-
-        thread.terminate
+      connections.each do |id, connection|
+        close_connection(id, connection)
       end
-
+    ensure
       connections.clear
     end
 
@@ -176,6 +201,24 @@ module Nonnative
 
     def read_state
       mutex.synchronize { state }
+    end
+
+    def register_connection(id, socket)
+      connections[id] = Connection.new(socket)
+    end
+
+    def attach_connection_thread(id, thread)
+      connections[id]&.thread = thread
+    end
+
+    def attach_connection_pair(id, pair)
+      connections[id]&.pair = pair
+    end
+
+    def close_connection(id, connection)
+      Nonnative.logger.info "closing connection for '#{id}' for proxy 'fault_injection'"
+
+      connection.close
     end
   end
 end

--- a/lib/nonnative/grpc_server.rb
+++ b/lib/nonnative/grpc_server.rb
@@ -33,8 +33,8 @@ module Nonnative
 
     # Binds the gRPC server and begins serving requests.
     #
-    # The server binds to the proxy host/port so that enabling a proxy results in traffic and readiness
-    # checks consistently targeting the proxy endpoint.
+    # The server binds to the upstream proxy host/port so the fault-injection proxy can expose the
+    # runner host/port as the client-facing endpoint used by readiness checks.
     #
     # @return [void]
     def perform_start

--- a/lib/nonnative/http_server.rb
+++ b/lib/nonnative/http_server.rb
@@ -48,8 +48,8 @@ module Nonnative
 
     # Binds the Puma server and begins serving.
     #
-    # The listener binds to the proxy host/port so that enabling a proxy results in traffic and
-    # readiness checks consistently targeting the proxy endpoint.
+    # The listener binds to the upstream proxy host/port so the fault-injection proxy can expose the
+    # runner host/port as the client-facing endpoint used by readiness checks.
     #
     # @return [void]
     def perform_start

--- a/lib/nonnative/socket_pair.rb
+++ b/lib/nonnative/socket_pair.rb
@@ -28,19 +28,27 @@ module Nonnative
     # @param local_socket [TCPSocket] the accepted client socket
     # @return [void]
     def connect(local_socket)
-      remote_socket = create_remote_socket
+      @local_socket = local_socket
+      @remote_socket = create_remote_socket
 
       loop do
-        ready = select([local_socket, remote_socket], nil, nil)
+        ready = select([@local_socket, @remote_socket], nil, nil)
 
-        break if pipe?(ready, local_socket, remote_socket)
-        break if pipe?(ready, remote_socket, local_socket)
+        break if pipe?(ready, @local_socket, @remote_socket)
+        break if pipe?(ready, @remote_socket, @local_socket)
       end
     ensure
-      Nonnative.logger.info "finished connect for local socket '#{local_socket.inspect}' and '#{remote_socket&.inspect}' for 'socket_pair'"
+      Nonnative.logger.info "finished connect for local socket '#{@local_socket.inspect}' and '#{@remote_socket&.inspect}' for 'socket_pair'"
 
-      local_socket.close
-      remote_socket&.close
+      close
+    end
+
+    # Closes any open sockets managed by this pair.
+    #
+    # @return [void]
+    def close
+      close_socket @local_socket
+      close_socket @remote_socket
     end
 
     protected
@@ -93,6 +101,14 @@ module Nonnative
     # @return [Integer] number of bytes written
     def write(socket, data)
       socket.write(data)
+    end
+
+    def close_socket(socket)
+      return if socket.nil? || socket.closed?
+
+      socket.close
+    rescue IOError
+      nil
     end
   end
 end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '2.13.0'
+  VERSION = '2.13.1'
 end


### PR DESCRIPTION
## What

- Fix fault-injection proxy shutdown so `stop` actively tears down live proxied connections instead of only closing the listener.
- Simplify the proxy connection lifecycle with a small `Connection` class and explicit register/attach/close helpers in [fault_injection_proxy.rb](/Users/alejandro/code/nonnative/lib/nonnative/fault_injection_proxy.rb).
- Add a lifecycle regression that opens a service connection through the proxy, sends traffic, stops the service runner, and verifies the client sees the disconnect in [lifecycle.feature](/Users/alejandro/code/nonnative/features/lifecycle.feature).
- Extend the service test fixture and steps to support the new shutdown coverage in [service.rb](/Users/alejandro/code/nonnative/features/support/service.rb) and [services_steps.rb](/Users/alejandro/code/nonnative/features/step_definitions/services_steps.rb).
- Update proxy wiring docs so runner `host`/`port` are consistently described as client-facing and nested `proxy.host`/`proxy.port` as the upstream target in [README.md](/Users/alejandro/code/nonnative/README.md), [http_server.rb](/Users/alejandro/code/nonnative/lib/nonnative/http_server.rb), and [grpc_server.rb](/Users/alejandro/code/nonnative/lib/nonnative/grpc_server.rb).

## Why

- Active proxied connections could survive service/proxy shutdown because the old stop path only shut down the accept loop and listening socket.
- That left shutdown behavior incomplete for long-lived connections and made lifecycle cleanup less deterministic.
- The proxy endpoint documentation was also inconsistent with the implementation, which made service proxy configuration easier to misunderstand.

## Testing

- `make lint`
- `bundle exec cucumber --profile report features/services.feature`
- `bundle exec cucumber --profile report features/lifecycle.feature:57`

I did not rerun full `make features`, `make benchmarks`, or `make sec` after the final refactors.