### PR TITLE
docs(readme): clarify proxy endpoint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,9 +547,13 @@ Nonnative.configure do |config|
   config.log = 'nonnative.log'
 
   config.process do |p|
+    p.host = '127.0.0.1'
+    p.port = 20_000
+
     p.proxy = {
       kind: 'fault_injection',
-      port: 20_000,
+      host: '127.0.0.1',
+      port: 12_321,
       log: 'proxy_server.log',
       wait: 1,
       options: {
@@ -569,9 +573,12 @@ url: http://localhost:4567
 log: nonnative.log
 processes:
   -
+    host: 127.0.0.1
+    port: 20000
     proxy:
       kind: fault_injection
-      port: 20000
+      host: 127.0.0.1
+      port: 12321
       log: proxy_server.log
       wait: 1
       options:
@@ -592,9 +599,13 @@ Nonnative.configure do |config|
   config.log = 'nonnative.log'
 
   config.server do |s|
+    s.host = '127.0.0.1'
+    s.port = 20_000
+
     s.proxy = {
       kind: 'fault_injection',
-      port: 20_000,
+      host: '127.0.0.1',
+      port: 12_321,
       log: 'proxy_server.log',
       wait: 1,
       options: {
@@ -614,9 +625,12 @@ url: http://localhost:4567
 log: nonnative.log
 servers:
   -
+    host: 127.0.0.1
+    port: 20000
     proxy:
       kind: fault_injection
-      port: 20000
+      host: 127.0.0.1
+      port: 12321
       log: proxy_server.log
       wait: 1
       options:

--- a/lib/nonnative/configuration_proxy.rb
+++ b/lib/nonnative/configuration_proxy.rb
@@ -15,8 +15,8 @@ module Nonnative
   # @see Nonnative.proxies
   class ConfigurationProxy
     # @return [String] proxy kind name (for example `"none"` or `"fault_injection"`)
-    # @return [String] proxy bind host (defaults to `"0.0.0.0"`)
-    # @return [Integer] proxy bind port (defaults to `0`)
+    # @return [String] upstream host used by proxy implementations (defaults to `"0.0.0.0"`)
+    # @return [Integer] upstream port used by proxy implementations (defaults to `0`)
     # @return [String, nil] path to proxy log file (implementation-dependent)
     # @return [Numeric] wait interval (seconds) after proxy state changes (defaults to `0.1`)
     # @return [Hash] proxy implementation options (implementation-dependent)

--- a/lib/nonnative/configuration_runner.rb
+++ b/lib/nonnative/configuration_runner.rb
@@ -51,8 +51,8 @@ module Nonnative
     #
     # @param value [Hash] proxy attributes
     # @option value [String] :kind proxy kind name (for example `"fault_injection"`)
-    # @option value [String] :host proxy bind host (optional)
-    # @option value [Integer] :port proxy bind port
+    # @option value [String] :host upstream host behind the proxy (optional)
+    # @option value [Integer] :port upstream port behind the proxy
     # @option value [String] :log proxy log file path
     # @option value [Numeric] :wait wait interval (seconds) after state changes (optional)
     # @option value [Hash] :options proxy implementation specific options


### PR DESCRIPTION
## What
- Updated README proxy examples for processes and servers to show both endpoint sides
- Clarified that runner `host` / `port` are the client-facing proxy endpoint
- Clarified that nested `proxy.host` / `proxy.port` are the upstream target in RDoc

## Why
- Prevent misconfigured proxy examples where clients and upstream services use the wrong endpoint
- Align user-facing docs with the runtime proxy wiring model

## Testing
- `make lint` passed