### PR TITLE
fix(proxy): extension contracts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (2.15.0)
+    nonnative (2.15.1)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/features/proxy_contract.feature
+++ b/features/proxy_contract.feature
@@ -1,0 +1,7 @@
+@contract @proxy @clear
+Feature: Proxy contracts
+  Preserve proxy extension and control behavior.
+
+  Scenario: Custom proxy kinds can be registered
+    When I register a custom proxy kind
+    Then the custom proxy kind should resolve to the custom proxy

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -42,8 +42,21 @@ When('I try to find the proxy for server {string}') do |name|
   capture_result(:@server_runner, :@error) { Nonnative.pool.server_by_name(name) }
 end
 
+When('I register a custom proxy kind') do
+  @previous_custom_proxy = Nonnative.proxies['custom']
+  Nonnative.proxies['custom'] = Nonnative::Features::CustomProxy
+end
+
 Then('I should get a proxy not found error') do
   expect(@error).to be_a_kind_of(Nonnative::NotFoundError)
+end
+
+Then('the custom proxy kind should resolve to the custom proxy') do
+  actual = Nonnative.proxy('custom')
+  Nonnative.proxies.delete('custom')
+  Nonnative.proxies['custom'] = @previous_custom_proxy if @previous_custom_proxy
+
+  expect(actual).to eq(Nonnative::Features::CustomProxy)
 end
 
 When('I send a successful message to the http proxy server') do

--- a/features/support/lifecycle_doubles.rb
+++ b/features/support/lifecycle_doubles.rb
@@ -39,6 +39,9 @@ module Nonnative
       end
     end
 
+    class CustomProxy < Nonnative::NoProxy
+    end
+
     class FailingService
       attr_reader :name
 

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -189,7 +189,7 @@ module Nonnative
     #
     # @return [Hash{String=>Class}]
     def proxies
-      @proxies ||= { 'fault_injection' => Nonnative::FaultInjectionProxy }.freeze
+      @proxies ||= { 'fault_injection' => Nonnative::FaultInjectionProxy }
     end
 
     # Resolves a proxy implementation for a configured kind.

--- a/lib/nonnative/cucumber.rb
+++ b/lib/nonnative/cucumber.rb
@@ -32,6 +32,13 @@ module Nonnative
     end
 
     module ProxySteps
+      PROXY_OPERATIONS = {
+        'close_all' => :close_all,
+        'delay' => :delay,
+        'invalid_data' => :invalid_data,
+        'reset' => :reset
+      }.freeze
+
       def install_proxy_steps
         install_proxy_mutation_steps
         install_proxy_reset_steps
@@ -40,17 +47,17 @@ module Nonnative
       def install_proxy_mutation_steps
         Given('I set the proxy for process {string} to {string}') do |name, operation|
           process = Nonnative.pool.process_by_name(name)
-          process.proxy.send(operation)
+          Nonnative::Cucumber::Registration.apply_proxy_operation(process.proxy, operation)
         end
 
         Given('I set the proxy for server {string} to {string}') do |name, operation|
           server = Nonnative.pool.server_by_name(name)
-          server.proxy.send(operation)
+          Nonnative::Cucumber::Registration.apply_proxy_operation(server.proxy, operation)
         end
 
         Given('I set the proxy for service {string} to {string}') do |name, operation|
           service = Nonnative.pool.service_by_name(name)
-          service.proxy.send(operation)
+          Nonnative::Cucumber::Registration.apply_proxy_operation(service.proxy, operation)
         end
       end
 
@@ -69,6 +76,14 @@ module Nonnative
           service = Nonnative.pool.service_by_name(name)
           service.proxy.reset
         end
+      end
+
+      def apply_proxy_operation(proxy, operation)
+        method = PROXY_OPERATIONS.fetch(operation) do
+          raise ArgumentError, "Unsupported proxy operation '#{operation}'"
+        end
+
+        proxy.public_send(method)
       end
     end
 

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '2.15.0'
+  VERSION = '2.15.1'
 end


### PR DESCRIPTION
## What
- Allow custom proxy kinds to be registered through the public `Nonnative.proxies` API
- Restrict Cucumber proxy control steps to supported public proxy operations
- Add public API contract coverage for custom proxy registration

## Why
- Align proxy registry behavior with the documented extension point
- Avoid invoking arbitrary proxy methods from feature text
- Keep tests focused on public behavior instead of implementation internals

## Testing
- `make features feature=features/proxy_contract.feature` passed
- `make lint` passed
- `make features` passed