### PR TITLE
docs(readme): clarify tcp-only readiness contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Runner fields (process/server/service):
 
 For `fault_injection`, the nested `proxy.host`/`proxy.port` describe the upstream target behind the proxy. In-process server implementations typically bind there via `proxy.host` / `proxy.port`.
 
+Nonnative readiness and shutdown checks are TCP-only. Configure ports that are dedicated to the test run; if another process is already listening on the same `host`/`port`, results are undefined.
+
 ### Lifecycle strategies (Cucumber integration)
 
 Nonnative ships Cucumber hooks (when loaded) that support these tags/strategies:


### PR DESCRIPTION
## What
- Added a note that Nonnative readiness and shutdown checks are TCP-only.
- Clarified that configured host/port values should be dedicated to the test run.

## Why
- Makes the port ownership contract explicit without changing runtime behavior.
- Helps users understand that results are undefined if another process is already listening on the same endpoint.

## Testing
- Ran `make lint` successfully.
