### PR TITLE
feat(cucumber): support generic unavailable health bodies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (2.15.1)
+    nonnative (2.16.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)
@@ -206,4 +206,4 @@ DEPENDENCIES
   simplecov-cobertura
 
 BUNDLED WITH
-  4.0.10
+  4.0.11

--- a/features/server_observability.feature
+++ b/features/server_observability.feature
@@ -11,6 +11,10 @@ Feature: Server observability
     Then I should receive a TCP "Hello World!" response
     And I should see "test" as healthy
 
+  Scenario: The health endpoint reports service unavailable as unhealthy
+    When the health endpoint reports service unavailable
+    Then I should see "test" as unhealthy
+
   Scenario Outline: The <endpoint> endpoint responds successfully
     When I send a "<endpoint>" request
     Then I should receive a successful "<endpoint>" response

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -34,6 +34,11 @@ When('I send a {string} request') do |name|
   @response = observability_request(name)
 end
 
+When('the health endpoint reports service unavailable') do
+  Nonnative::Features::Application.health_body = "Service Unavailable\n"
+  Nonnative::Features::Application.health_status = 503
+end
+
 When('I send a not found message with the http client to the servers') do
   @response = http_client_for_server('http_server_1').not_found
 end

--- a/features/support/http_server.rb
+++ b/features/support/http_server.rb
@@ -15,6 +15,13 @@ module Nonnative
     end
 
     class Application < Sinatra::Application
+      class << self
+        attr_accessor :health_body, :health_status
+      end
+
+      self.health_body = ''
+      self.health_status = 200
+
       configure do
         set :logging, false
       end
@@ -67,7 +74,8 @@ module Nonnative
       end
 
       get '/test/healthz' do
-        status 200
+        status Nonnative::Features::Application.health_status
+        Nonnative::Features::Application.health_body
       end
 
       get '/test/livez' do

--- a/features/support/step_support/server_configuration.rb
+++ b/features/support/step_support/server_configuration.rb
@@ -80,6 +80,9 @@ module Nonnative
         ].freeze
 
         def configure_servers_programmatically
+          Nonnative::Features::Application.health_body = ''
+          Nonnative::Features::Application.health_status = 200
+
           configure_with_defaults do |config|
             SERVER_DEFINITIONS.each { |definition| add_server(config, definition) }
           end

--- a/lib/nonnative/cucumber.rb
+++ b/lib/nonnative/cucumber.rb
@@ -88,6 +88,8 @@ module Nonnative
     end
 
     module LifecycleSteps
+      SERVICE_UNAVAILABLE = 'Service Unavailable'
+
       def install_state_steps
         install_start_step
         install_attempt_start_step
@@ -125,7 +127,11 @@ module Nonnative
 
         Then('I should see {string} as unhealthy') do |service|
           wait_for { Nonnative.observability.health(opts).code }.to eq(503)
-          wait_for { Nonnative.observability.health(opts).body }.to include(service)
+          wait_for { Nonnative.observability.health(opts).body }.to satisfy do |body|
+            body = body.to_s.strip
+
+            body == SERVICE_UNAVAILABLE || body.include?(service)
+          end
         end
       end
 
@@ -134,7 +140,11 @@ module Nonnative
 
         Then('I should see {string} as healthy') do |service|
           wait_for { Nonnative.observability.health(opts).code }.to eq(200)
-          wait_for { Nonnative.observability.health(opts).body }.to_not include(service)
+          wait_for { Nonnative.observability.health(opts).body }.to satisfy do |body|
+            body = body.to_s.strip
+
+            body != SERVICE_UNAVAILABLE && !body.include?(service)
+          end
         end
       end
 

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '2.15.1'
+  VERSION = '2.16.0'
 end


### PR DESCRIPTION
## What

- Normalize health response bodies in the Cucumber healthy and unhealthy steps before checking service status.
- Accept the generic Service Unavailable body for 503 unhealthy responses while preserving the previous service-name fallback.
- Add server observability coverage and fixture controls for the new 503 response shape.
- Bump the gem version to 2.16.0 and refresh Gemfile.lock.

## Why

- Health endpoints can now return a generic Service Unavailable body instead of naming the unhealthy service, and the public Cucumber steps need to keep working with both formats.

## Testing

- make features feature=features/server_observability.feature - passed
- make lint - passed
