### PR TITLE
feat(config): load yaml configs safely

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ Fault-injection states: `none`, `close_all`, `delay`, `invalid_data`.
 
 Config rules:
 
+- YAML config is loaded as data only via `Nonnative::ConfigurationFile`; ERB is not evaluated and arbitrary Ruby object tags are rejected
 - YAML services belong under `services:`, not `processes:`
 - There is no top-level `config.wait`; `wait` is per runner
 - Programmatic service config uses `config.service do |s| ... end`, so use `s.host` / `s.port`
@@ -107,4 +108,4 @@ Limitations:
 - Process lifecycle: `lib/nonnative/process.rb`
 - Proxies: `lib/nonnative/fault_injection_proxy.rb`, `lib/nonnative/socket_pair_factory.rb`
 - Cucumber: `lib/nonnative/cucumber.rb`, `lib/nonnative/startup.rb`, `features/support/env.rb`
-- Config loading: `lib/nonnative/configuration.rb`, `lib/nonnative/configuration_runner.rb`, `lib/nonnative/configuration_proxy.rb`
+- Config loading: `lib/nonnative/configuration.rb`, `lib/nonnative/configuration_file.rb`, `lib/nonnative/configuration_runner.rb`, `lib/nonnative/configuration_proxy.rb`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (2.16.0)
+    nonnative (2.17.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ gem install nonnative
 ## Usage
 
 Nonnative is configured via {#Nonnative.configure} (programmatic) or `config.load_file(...)` (YAML).
+YAML configuration is loaded as data only: ERB is not evaluated and arbitrary Ruby objects are not
+deserialized.
 
 High-level configuration fields:
 - `version`: configuration version (example: `"1.0"`).

--- a/features/configuration_loading.feature
+++ b/features/configuration_loading.feature
@@ -14,3 +14,12 @@ Feature: Configuration loading
   Scenario: Top-level wait does not override runner wait defaults
     Given I load a temporary configuration with a top-level wait and a process
     Then the configured process "default_wait_process" should have wait 0.1
+
+  Scenario: YAML configuration does not evaluate ERB
+    Given I load a temporary configuration containing ERB
+    Then the ERB side effect should not happen
+    And the configuration name should be the ERB source
+
+  Scenario: YAML configuration rejects arbitrary Ruby objects
+    When I attempt to load a temporary configuration with a Ruby object tag
+    Then loading the configuration should fail with a YAML safety error

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -53,6 +53,27 @@ Given('I load a temporary configuration with a top-level wait and a process') do
   YAML
 end
 
+Given('I load a temporary configuration containing ERB') do
+  @erb_side_effect_path = "test/reports/#{SecureRandom.hex(4)}"
+  load_temporary_configuration(<<~YAML)
+    version: "1.0"
+    name: <%= File.write(#{@erb_side_effect_path.inspect}, 'evaluated') %>
+    url: http://localhost:4567
+    log: test/reports/nonnative.log
+  YAML
+end
+
+When('I attempt to load a temporary configuration with a Ruby object tag') do
+  @configuration_error = nil
+  capture_result(:@configuration_result, :@configuration_error) do
+    load_temporary_configuration(<<~YAML)
+      --- !ruby/object:Object
+      version: "1.0"
+      name: test
+    YAML
+  end
+end
+
 Then('the configuration should contain {int} service entry and {int} process entries') do |services, processes|
   expect(Nonnative.configuration.services.size).to eq(services)
   expect(Nonnative.configuration.processes.size).to eq(processes)
@@ -76,6 +97,18 @@ Then('the configured process {string} should have wait {float}') do |name, wait|
   process = configured_process(name)
 
   expect(process.wait).to eq(wait)
+end
+
+Then('the ERB side effect should not happen') do
+  expect(File.exist?(@erb_side_effect_path)).to be(false)
+end
+
+Then('the configuration name should be the ERB source') do
+  expect(Nonnative.configuration.name).to eq("<%= File.write(#{@erb_side_effect_path.inspect}, 'evaluated') %>")
+end
+
+Then('loading the configuration should fail with a YAML safety error') do
+  expect(@configuration_error).to be_a(Psych::DisallowedClass)
 end
 
 def load_temporary_configuration(contents)

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -67,6 +67,7 @@ require 'nonnative/stop_error'
 require 'nonnative/not_found_error'
 require 'nonnative/timeout'
 require 'nonnative/port'
+require 'nonnative/configuration_file'
 require 'nonnative/configuration'
 require 'nonnative/configuration_runner'
 require 'nonnative/configuration_process'
@@ -112,16 +113,6 @@ module Nonnative
     #
     # @return [Nonnative::Pool, nil] the pool instance, or `nil` if not started yet
     attr_accessor :pool
-
-    # Loads one or more configuration files using the `config` gem.
-    #
-    # This is primarily used by {Nonnative::Configuration#load_file}, but is public for advanced cases.
-    #
-    # @param files [Array<String>] paths to configuration files
-    # @return [Config::Options] the loaded configuration object
-    def configurations(*files)
-      Config.load_files(files)
-    end
 
     # Returns the current configuration (memoized).
     #

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -52,13 +52,14 @@ module Nonnative
 
     # Loads a configuration file and appends its runners to this instance.
     #
-    # The file is loaded using the `config` gem via {Nonnative.configurations}. Top-level attributes are
-    # copied onto this object, and runner sections are transformed into configuration runner objects.
+    # The file is loaded using safe YAML parsing. ERB is not evaluated,
+    # arbitrary object deserialization is not allowed, top-level attributes are copied onto this object,
+    # and runner sections are transformed into configuration runner objects.
     #
     # @param path [String] path to a configuration file (typically YAML)
     # @return [void]
     def load_file(path)
-      cfg = Nonnative.configurations(path)
+      cfg = Nonnative::ConfigurationFile.load(path)
 
       self.version = cfg.version
       self.name = cfg.name

--- a/lib/nonnative/configuration_file.rb
+++ b/lib/nonnative/configuration_file.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Nonnative
+  # Safely loads a YAML configuration file into the Config::Options shape used by Nonnative.
+  class ConfigurationFile
+    class << self
+      # Loads a file into a Config::Options instance.
+      #
+      # YAML files are parsed as data only: ERB is not evaluated and arbitrary object deserialization is not allowed.
+      #
+      # @param path [String] file path
+      # @return [Config::Options]
+      def load(path)
+        Config::Options.new.tap do |config|
+          config.add_source!(safe_load_yaml(path))
+          config.load!
+        end
+      end
+
+      private
+
+      def safe_load_yaml(path)
+        contents = File.read(path)
+        config = YAML.safe_load(contents, aliases: true) || {}
+        return config if config.is_a?(Hash)
+
+        raise ArgumentError, "Configuration file '#{path}' must contain a YAML mapping"
+      rescue Psych::SyntaxError => e
+        raise ArgumentError, "YAML syntax error occurred while parsing #{path}: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '2.16.0'
+  VERSION = '2.17.0'
 end


### PR DESCRIPTION
## What

- Load YAML configuration files through a safe single-file parser instead of delegating to the config gem unsafe loader.
- Reject ERB execution and arbitrary Ruby object tags in YAML configuration.
- Remove the unused Nonnative.configurations helper and route config.load_file through Nonnative::ConfigurationFile.
- Add Cucumber coverage for ERB staying literal and Ruby object tags being rejected.
- Document the YAML safety behavior in README and AGENTS.
- Bump the gem version to 2.17.0.

## Why

- Prevent configuration files from executing Ruby while preserving the normal Nonnative.configure { |config| config.load_file(...) } workflow.
- Keep the file-loading contract narrow: one YAML file in, Config::Options out.

## Testing

- `make lint` - passed
- `bundle exec cucumber features/configuration_loading.feature` - passed
- `make features` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
