### PR TITLE
feat(config): default bind hosts to loopback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Fault-injection states: `none`, `close_all`, `delay`, `invalid_data`.
 Config rules:
 
 - YAML config is loaded as data only via `Nonnative::ConfigurationFile`; ERB is not evaluated and arbitrary Ruby object tags are rejected
+- Runner `host` and nested `proxy.host` default to `127.0.0.1`; use explicit `0.0.0.0` only when external access is intended
 - YAML services belong under `services:`, not `processes:`
 - There is no top-level `config.wait`; `wait` is per runner
 - Programmatic service config uses `config.service do |s| ... end`, so use `s.host` / `s.port`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (2.17.0)
+    nonnative (2.18.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ High-level configuration fields:
 Runner fields (process/server/service):
 - `timeout`: max time (seconds) for readiness/shutdown port checks.
 - `wait`: small sleep (seconds) between lifecycle steps.
-- `host`/`port`: client-facing address used for readiness/shutdown port checks. When a `fault_injection` proxy is enabled, this is the endpoint your tests/clients should hit.
+- `host`/`port`: client-facing address used for readiness/shutdown port checks. `host` defaults to `127.0.0.1`. When a `fault_injection` proxy is enabled, this is the endpoint your tests/clients should hit.
 - `log`: per-runner log file (used by process output redirection or server implementations).
 
-For `fault_injection`, the nested `proxy.host`/`proxy.port` describe the upstream target behind the proxy. In-process server implementations typically bind there via `proxy.host` / `proxy.port`.
+For `fault_injection`, the nested `proxy.host`/`proxy.port` describe the upstream target behind the proxy. Nested `proxy.host` also defaults to `127.0.0.1`. In-process server implementations typically bind there via `proxy.host` / `proxy.port`.
 
 Nonnative readiness and shutdown checks are TCP-only. Configure ports that are dedicated to the test run; if another process is already listening on the same `host`/`port`, results are undefined.
 

--- a/features/configuration_loading.feature
+++ b/features/configuration_loading.feature
@@ -15,6 +15,11 @@ Feature: Configuration loading
     Given I load a temporary configuration with a top-level wait and a process
     Then the configured process "default_wait_process" should have wait 0.1
 
+  Scenario: Missing hosts default to loopback
+    Given I load a temporary configuration with omitted hosts
+    Then the configured process "default_host_process" should use host "127.0.0.1"
+    And the configured process "default_host_process" proxy should use host "127.0.0.1"
+
   Scenario: YAML configuration does not evaluate ERB
     Given I load a temporary configuration containing ERB
     Then the ERB side effect should not happen

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -63,6 +63,25 @@ Given('I load a temporary configuration containing ERB') do
   YAML
 end
 
+Given('I load a temporary configuration with omitted hosts') do
+  load_temporary_configuration(<<~YAML)
+    version: "1.0"
+    name: test
+    url: http://localhost:4567
+    log: test/reports/nonnative.log
+    processes:
+      - name: default_host_process
+        command: features/support/bin/start 12_400
+        timeout: 1
+        port: 12400
+        log: test/reports/12_400.log
+        proxy:
+          kind: fault_injection
+          port: 30000
+          log: test/reports/proxy_default_host_process.log
+  YAML
+end
+
 When('I attempt to load a temporary configuration with a Ruby object tag') do
   @configuration_error = nil
   capture_result(:@configuration_result, :@configuration_error) do
@@ -97,6 +116,18 @@ Then('the configured process {string} should have wait {float}') do |name, wait|
   process = configured_process(name)
 
   expect(process.wait).to eq(wait)
+end
+
+Then('the configured process {string} should use host {string}') do |name, host|
+  process = configured_process(name)
+
+  expect(process.host).to eq(host)
+end
+
+Then('the configured process {string} proxy should use host {string}') do |name, host|
+  process = configured_process(name)
+
+  expect(process.proxy.host).to eq(host)
 end
 
 Then('the ERB side effect should not happen') do

--- a/lib/nonnative/configuration_proxy.rb
+++ b/lib/nonnative/configuration_proxy.rb
@@ -15,7 +15,7 @@ module Nonnative
   # @see Nonnative.proxies
   class ConfigurationProxy
     # @return [String] proxy kind name (for example `"none"` or `"fault_injection"`)
-    # @return [String] upstream host used by proxy implementations (defaults to `"0.0.0.0"`)
+    # @return [String] upstream host used by proxy implementations (defaults to `"127.0.0.1"`)
     # @return [Integer] upstream port used by proxy implementations (defaults to `0`)
     # @return [String, nil] path to proxy log file (implementation-dependent)
     # @return [Numeric] wait interval (seconds) after proxy state changes (defaults to `0.1`)
@@ -27,7 +27,7 @@ module Nonnative
     #
     # Defaults:
     # - `kind`: `"none"`
-    # - `host`: `"0.0.0.0"`
+    # - `host`: `"127.0.0.1"`
     # - `port`: `0`
     # - `wait`: `0.1`
     # - `options`: `{}`
@@ -35,7 +35,7 @@ module Nonnative
     # @return [void]
     def initialize
       self.kind = 'none'
-      self.host = '0.0.0.0'
+      self.host = '127.0.0.1'
       self.port = 0
       self.wait = 0.1
       self.options = {}

--- a/lib/nonnative/configuration_runner.rb
+++ b/lib/nonnative/configuration_runner.rb
@@ -14,7 +14,7 @@ module Nonnative
   # @see Nonnative::ConfigurationService
   class ConfigurationRunner
     # @return [String, nil] runner name used for lookup (for example via `pool.process_by_name`)
-    # @return [String] host to bind/connect to (defaults to `"0.0.0.0"`)
+    # @return [String] host to bind/connect to (defaults to `"127.0.0.1"`)
     # @return [Integer] port to bind/connect to
     # @return [Numeric] wait interval (seconds) used by runners between lifecycle steps
     attr_accessor :name, :host, :port, :wait
@@ -30,14 +30,14 @@ module Nonnative
     # Creates a runner configuration with defaults.
     #
     # Defaults:
-    # - `host`: `"0.0.0.0"`
+    # - `host`: `"127.0.0.1"`
     # - `port`: `0`
     # - `wait`: `0.1`
     # - `proxy`: a new {Nonnative::ConfigurationProxy} with its own defaults
     #
     # @return [void]
     def initialize
-      self.host = '0.0.0.0'
+      self.host = '127.0.0.1'
       self.port = 0
       self.wait = 0.1
 

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '2.17.0'
+  VERSION = '2.18.0'
 end


### PR DESCRIPTION
## What

- Change runner and nested proxy host defaults from `0.0.0.0` to `127.0.0.1`.
- Add configuration coverage for omitted runner and proxy hosts defaulting to loopback.
- Document the new loopback default in README and AGENTS.
- Bump the gem version to 2.18.0.

## Why

- Avoid exposing test processes, servers, and fault-injection proxies on all network interfaces unless callers explicitly opt in with `0.0.0.0`.

## Testing

- `bundle exec cucumber features/configuration_loading.feature` - passed
- `make lint` - passed
- `make features` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
