### PR TITLE
feat(process): execute argv commands without shell parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Config rules:
 
 - YAML config is loaded as data only via `Nonnative::ConfigurationFile`; ERB is not evaluated and arbitrary Ruby object tags are rejected
 - Runner `host` and nested `proxy.host` default to `127.0.0.1`; use explicit `0.0.0.0` only when external access is intended
+- Process `command` can be a legacy shell string or an argv array; prefer argv arrays for new config, and `go:` config builds argv internally
 - YAML services belong under `services:`, not `processes:`
 - There is no top-level `config.wait`; `wait` is per runner
 - Programmatic service config uses `config.service do |s| ... end`, so use `s.host` / `s.port`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (2.18.0)
+    nonnative (2.19.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ This calls `Nonnative.start` immediately and registers an `at_exit` stop.
 ### Processes
 
 A process is some sort of command that you would run locally.
+Commands can be strings or argv arrays. String commands preserve legacy shell semantics, while argv arrays
+avoid shell interpretation and are preferred for new configuration.
 
 Setup it up programmatically:
 
@@ -106,7 +108,7 @@ Nonnative.configure do |config|
 
   config.process do |p|
     p.name = 'start_1'
-    p.command = -> { 'features/support/bin/start 12_321' }
+    p.command = -> { ['features/support/bin/start', '12_321'] }
     p.timeout = 5
     p.wait = 0.1
     p.port = 12_321
@@ -138,7 +140,9 @@ log: nonnative.log
 processes:
   -
     name: start_1
-    command: features/support/bin/start 12_321
+    command:
+      - features/support/bin/start
+      - "12_321"
     timeout: 5
     wait: 1
     port: 12321
@@ -764,7 +768,7 @@ Then I should reset the proxy for service 'service_1'
 
 ### Go
 
-As we love using go as a language for services we have added support to start binaries with defined parameters. This expects that you build your services in the format of `command sub_command --params`
+As we love using go as a language for services we have added support to start binaries with defined parameters. This expects that you build your services in the format of `command sub_command --params`. YAML `go:` configuration is executed as argv entries, without shell interpretation.
 
 To get this to work you will need to create a `main_test.go` file with these contents:
 
@@ -786,12 +790,16 @@ Then to compile this binary you will need to do the following:
 go test -mod vendor -c -tags features -covermode=count -o your_binary -coverpkg=./... github.com/your_location
 ```
 
-Setup it up programmatically:
+Setup it up programmatically as an argv process command:
 
 ```ruby
-tools = %w[prof trace cover]
-
-Nonnative.go_executable(tools, 'reports', 'your_binary', 'sub_command', '--config config.yaml')
+Nonnative.configure do |config|
+  config.process do |p|
+    p.name = 'go'
+    p.command = -> { ['your_binary', 'sub_command', '--config', 'config.yaml'] }
+    p.port = 12_345
+  end
+end
 ```
 
 Setup it up through configuration:

--- a/features/command.feature
+++ b/features/command.feature
@@ -8,7 +8,7 @@ Feature: Command
       | executable | thisshouldbelong |
       | command    | server           |
       | parameters | --level=info     |
-    Then I should have a valid go command with:
+    Then I should have a valid go command argv with:
       | output     | reports          |
       | executable | thisshouldbelong |
       | command    | server           |
@@ -20,7 +20,7 @@ Feature: Command
       | executable | thisshouldbelong |
       | command    | server           |
       | parameters |                  |
-    Then I should have a valid go command with:
+    Then I should have a valid go command argv with:
       | output     | reports          |
       | executable | thisshouldbelong |
       | command    | server           |
@@ -29,7 +29,7 @@ Feature: Command
   @config
   Scenario: Go command from configuration
     When I load the go configuration
-    Then I should have a valid go command with:
+    Then I should have a valid go command argv with:
       | output     | reports          |
       | executable | thisshouldbelong |
       | command    | server           |

--- a/features/processes.feature
+++ b/features/processes.feature
@@ -26,6 +26,13 @@ Feature: Process runners
     And I should see a log entry of "test" in the file "test/reports/12_321.log"
     And the process 'start_1' should consume less than '40mb' of memory
 
+  Scenario: Process argv commands do not invoke the shell
+    Given I configure the system programmatically with an argv process
+    And I start the system
+    When I send "test" with the TCP client 'argv_process' to the process
+    Then I should receive a TCP "test" response from the process
+    And the argv process shell side effect should not happen
+
   @proxy @reset
   Scenario: A delayed process proxy still allows TCP responses
     Given I configure the system programmatically with processes

--- a/features/step_definitions/command_steps.rb
+++ b/features/step_definitions/command_steps.rb
@@ -2,8 +2,10 @@
 
 When('I create a go command with:') do |table|
   rows = table.rows_hash
+  params = rows['parameters']
+  params = nil if params == ''
 
-  @exec_path = Nonnative.go_executable([], rows['output'], rows['executable'], rows['command'], rows['parameters'])
+  @exec_path = Nonnative.go_executable_args([], rows['output'], rows['executable'], rows['command'], params)
 end
 
 When('I load the go configuration') do
@@ -14,28 +16,39 @@ When('I load the go configuration') do
   @exec_path = Nonnative.configuration.processes.first.command.call
 end
 
-Then('I should have a valid go command with:') do |table|
+Then('I should have a valid go command argv with:') do |table|
+  expect(@exec_path).to be_an(Array)
+  expect_valid_go_command(table, @exec_path)
+end
+
+def expect_valid_go_command(table, parts)
   rows = table.rows_hash
   params = rows['parameters']
   output = rows['output']
   exec = rows['executable']
   cmd = rows['command']
-  parts = @exec_path.split
 
   expect(parts.first).to eq(exec)
+  parts = expect_go_command_parts(parts, cmd, params)
 
-  if params == ''
-    expect(parts.last).to eq(cmd)
+  expect_go_command_flags(parts, output, exec, cmd)
+end
 
-    parts = parts[1..-2]
-  else
-    expect(parts[-2]).to eq(cmd)
-    expect(parts.last).to eq(params)
+def expect_go_command_parts(parts, cmd, params)
+  return expect_go_command_without_params(parts, cmd) if params == ''
 
-    parts = parts[1..-3]
-  end
+  expect(parts[-2]).to eq(cmd)
+  expect(parts.last).to eq(params)
 
-  parts.each do |p|
-    expect(p).to include("#{output}/#{exec}-#{cmd}")
-  end
+  parts[1..-3]
+end
+
+def expect_go_command_without_params(parts, cmd)
+  expect(parts.last).to eq(cmd)
+
+  parts[1..-2]
+end
+
+def expect_go_command_flags(parts, output, exec, cmd)
+  parts.each { |p| expect(p).to include("#{output}/#{exec}-#{cmd}") }
 end

--- a/features/step_definitions/processes_steps.rb
+++ b/features/step_definitions/processes_steps.rb
@@ -8,6 +8,22 @@ Given('I configure the system through configuration with processes') do
   load_configuration('features/configs/processes.yml')
 end
 
+Given('I configure the system programmatically with an argv process') do
+  @argv_side_effect_path = "test/reports/#{SecureRandom.hex(4)}"
+  configure_with_defaults do |config|
+    config.process do |process|
+      process.name = 'argv_process'
+      process.command = -> { ['features/support/bin/start', "12401; touch #{@argv_side_effect_path}"] }
+      process.timeout = 5
+      process.wait = 0.1
+      process.host = '127.0.0.1'
+      process.port = 12_401
+      process.log = 'test/reports/12_401.log'
+      process.signal = 'INT'
+    end
+  end
+end
+
 When('I send {string} with the TCP client to the processes') do |message|
   @responses = %w[start_1 start_2].map { |name| tcp_client_for_process(name).request(message) }
 end
@@ -22,6 +38,14 @@ end
 
 Then('I should receive a TCP {string} response') do |response|
   @responses.each { |r| expect(r).to eq(response) }
+end
+
+Then('I should receive a TCP {string} response from the process') do |response|
+  expect(@response).to eq(response)
+end
+
+Then('the argv process shell side effect should not happen') do
+  expect(File.exist?(@argv_side_effect_path)).to be(false)
 end
 
 Then('I should receive a connection error for client response with TCP') do

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -153,7 +153,7 @@ module Nonnative
       File.readlines(path).select { |l| predicate.call(l) }
     end
 
-    # Builds a Go test executable command line with optional profiling/trace/coverage flags.
+    # Builds a Go test executable argv array with optional profiling/trace/coverage flags.
     #
     # This is used when process configuration specifies a `go` section.
     #
@@ -162,9 +162,9 @@ module Nonnative
     # @param exec [String] the test binary (or wrapper) to execute
     # @param cmd [String] the command argument passed to the test binary
     # @param params [Array<String>] extra parameters for the command
-    # @return [String] executable command string
-    def go_executable(tools, output, exec, cmd, *params)
-      Nonnative::GoCommand.new(tools, exec, output).executable(cmd, params)
+    # @return [Array<String>] executable argv entries
+    def go_executable_args(tools, output, exec, cmd, *params)
+      Nonnative::GoCommand.new(tools, exec, output).executable_args(cmd, *params)
     end
 
     # Returns an HTTP client for common health/readiness endpoints.

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -141,7 +141,7 @@ module Nonnative
         params = go.parameters || []
         tools = go.tools || []
 
-        -> { Nonnative.go_executable(tools, go.output, go.executable, go.command, *params) }
+        -> { Nonnative.go_executable_args(tools, go.output, go.executable, go.command, *params) }
       else
         -> { process.command }
       end

--- a/lib/nonnative/configuration_process.rb
+++ b/lib/nonnative/configuration_process.rb
@@ -11,11 +11,21 @@ module Nonnative
   # @see Nonnative::Configuration
   # @see Nonnative::Process
   class ConfigurationProcess < ConfigurationRunner
-    # @return [Proc] a callable that returns the command string to execute (e.g. `-> { "./bin/api" }`)
+    # @return [Proc] a callable that returns the command to execute
+    #   as a shell string or argv array
+    #   (e.g. `-> { "./bin/api" }` or `-> { ["./bin/api", "--port", "8080"] }`)
+    attr_accessor :command
+
     # @return [String, nil] signal name to use for stopping (defaults to `"INT"` when not set)
+    attr_accessor :signal
+
     # @return [Numeric] readiness timeout (seconds) used when waiting for the port to open/close
+    attr_accessor :timeout
+
     # @return [String] log file path to append process stdout/stderr to
+    attr_accessor :log
+
     # @return [Hash, nil] environment variables to pass to the spawned process
-    attr_accessor :command, :signal, :timeout, :log, :environment
+    attr_accessor :environment
   end
 end

--- a/lib/nonnative/go_command.rb
+++ b/lib/nonnative/go_command.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module Nonnative
-  # Builds command lines for running a Go test binary with optional profiling/trace/coverage flags.
+  # Builds commands for running a Go test binary with optional profiling/trace/coverage flags.
   #
-  # This helper is used by {Nonnative.go_executable} and by YAML configuration when a process has a
-  # `go:` section (see {Nonnative::Configuration}).
+  # This helper is used by YAML configuration when a process has a `go:` section
+  # (see {Nonnative::Configuration}).
   #
   # The generated flags use Go's `testing` package flags (e.g. `-test.cpuprofile=...`), so this
   # is intended to run a binary compiled from `go test -c`.
@@ -21,10 +21,10 @@ module Nonnative
   #
   # @example
   #   cmd = Nonnative::GoCommand.new(%w[prof cover], './svc.test', 'reports')
-  #   cmd.executable('serve', '--config', 'config.yaml')
-  #   # => "./svc.test -test.cpuprofile=... -test.coverprofile=... serve --config config.yaml"
+  #   cmd.executable_args('serve', '--config', 'config.yaml')
+  #   # => ["./svc.test", "-test.cpuprofile=...", "-test.coverprofile=...", "serve", "--config", "config.yaml"]
   #
-  # @see Nonnative.go_executable
+  # @see Nonnative.go_executable_args
   class GoCommand
     # @param tools [Array<String>, nil] tool names to enable (see class docs)
     # @param exec [String] path to the compiled Go test binary
@@ -35,16 +35,15 @@ module Nonnative
       @output = output
     end
 
-    # Returns an executable command string including enabled `-test.*` flags.
+    # Returns an executable argv array including enabled `-test.*` flags.
     #
     # A short random suffix is appended to output filenames to reduce collisions across runs.
     #
     # @param cmd [String] command/sub-command argument passed to the Go test binary
     # @param params [Array<String>] additional parameters passed after `cmd`
-    # @return [String] the full command to execute
-    def executable(cmd, *params)
-      params = params.join(' ')
-      "#{exec} #{flags(cmd).join(' ')} #{cmd} #{params}".strip
+    # @return [Array<String>] argv entries to execute
+    def executable_args(cmd, *params)
+      [exec, *flags(cmd), cmd, *params.flatten.compact.map(&:to_s)]
     end
 
     private

--- a/lib/nonnative/process.rb
+++ b/lib/nonnative/process.rb
@@ -89,10 +89,10 @@ module Nonnative
         environment[k] = ENV.fetch(k, nil) || environment[k]
       end
 
-      command = service.command.call
+      command = Array(service.command.call)
 
-      spawn(environment, command, %i[out err] => [service.log, 'a']).tap do |pid|
-        Nonnative.logger.info "started '#{command}' with pid '#{pid}'"
+      spawn(environment, *command, %i[out err] => [service.log, 'a']).tap do |pid|
+        Nonnative.logger.info "started '#{command.join(' ')}' with pid '#{pid}'"
       end
     end
 

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '2.18.0'
+  VERSION = '2.19.0'
 end


### PR DESCRIPTION
## What

- Added argv-array command support while preserving legacy string command behavior.
- Routed YAML go configuration through argv construction and removed the internal string go command helper.
- Updated process/go docs, repository guidance, Cucumber coverage, and bumped the gem to 2.19.0.

## Why

- Avoid shell interpretation for new and generated command configuration, reducing shell-injection risk while keeping existing string configs compatible.

## Testing

- `bundle exec cucumber features/command.feature features/processes.feature` - passed
- `make lint` - passed
- `make sec` - passed
- `make features` - passed
- `git diff --check` - passed
