### PR TITLE
fix(go_command): split yaml parameters into argv words

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (2.19.0)
+    nonnative (2.19.1)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ Nonnative.configure do |config|
 end
 ```
 
-YAML `go:` configuration is for Go test binaries compiled with `go test -c`. It builds argv entries in this order: executable, optional `-test.*` profiling/trace/coverage flags, command, then parameters. The argv entries are executed without shell interpretation.
+YAML `go:` configuration is for Go test binaries compiled with `go test -c`. It builds argv entries in this order: executable, optional `-test.*` profiling/trace/coverage flags, command, then parameters. Parameter strings are parsed into argv words with shell-style quoting, but the argv entries are executed without shell interpretation.
 
 To get this to work you will need to create a `main_test.go` file with these contents:
 
@@ -826,8 +826,7 @@ processes:
       executable: your_binary
       command: sub_command
       parameters:
-        - --config
-        - config.yaml
+        - "-i file:.config/server.yml"
     timeout: 5
     port: 8000
     log: go.log

--- a/features/command.feature
+++ b/features/command.feature
@@ -14,6 +14,18 @@ Feature: Command
       | command    | server           |
       | parameters | --level=info     |
 
+  Scenario: Go command with shell-style parameter words
+    When I create a go command with:
+      | output     | reports                    |
+      | executable | thisshouldbelong           |
+      | command    | server                     |
+      | parameters | -i file:.config/server.yml |
+    Then I should have a valid go command argv with:
+      | output     | reports                    |
+      | executable | thisshouldbelong           |
+      | command    | server                     |
+      | parameters | -i,file:.config/server.yml |
+
   Scenario: Go command without parameters
     When I create a go command with:
       | output     | reports          |

--- a/features/step_definitions/command_steps.rb
+++ b/features/step_definitions/command_steps.rb
@@ -37,10 +37,11 @@ end
 def expect_go_command_parts(parts, cmd, params)
   return expect_go_command_without_params(parts, cmd) if params == ''
 
-  expect(parts[-2]).to eq(cmd)
-  expect(parts.last).to eq(params)
+  parameters = params.split(',')
+  expect(parts.last(parameters.length)).to eq(parameters)
+  expect(parts[-(parameters.length + 1)]).to eq(cmd)
 
-  parts[1..-3]
+  parts[1...-(parameters.length + 1)]
 end
 
 def expect_go_command_without_params(parts, cmd)

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -46,6 +46,7 @@ require 'timeout'
 require 'yaml'
 require 'open3'
 require 'securerandom'
+require 'shellwords'
 
 require 'grpc'
 require 'sinatra'
@@ -161,7 +162,7 @@ module Nonnative
     # @param output [String] directory where outputs should be written
     # @param exec [String] the test binary (or wrapper) to execute
     # @param cmd [String] the command argument passed to the test binary
-    # @param params [Array<String>] extra parameters for the command
+    # @param params [Array<String>] extra parameter strings for the command
     # @return [Array<String>] executable argv entries
     def go_executable_args(tools, output, exec, cmd, *params)
       Nonnative::GoCommand.new(tools, exec, output).executable_args(cmd, *params)

--- a/lib/nonnative/go_command.rb
+++ b/lib/nonnative/go_command.rb
@@ -19,6 +19,8 @@ module Nonnative
   #
   # If `tools` is `nil` or empty, all tools (`prof`, `trace`, `cover`) are enabled.
   #
+  # Parameter strings are parsed into argv words using shell-style quoting, then executed without a shell.
+  #
   # @example
   #   cmd = Nonnative::GoCommand.new(%w[prof cover], './svc.test', 'reports')
   #   cmd.executable_args('serve', '--config', 'config.yaml')
@@ -40,15 +42,19 @@ module Nonnative
     # A short random suffix is appended to output filenames to reduce collisions across runs.
     #
     # @param cmd [String] command/sub-command argument passed to the Go test binary
-    # @param params [Array<String>] additional parameters passed after `cmd`
+    # @param params [Array<String>] additional parameter strings passed after `cmd`
     # @return [Array<String>] argv entries to execute
     def executable_args(cmd, *params)
-      [exec, *flags(cmd), cmd, *params.flatten.compact.map(&:to_s)]
+      [exec, *flags(cmd), cmd, *parameter_args(params)]
     end
 
     private
 
     attr_reader :tools, :exec, :output
+
+    def parameter_args(params)
+      params.flatten.compact.flat_map { |p| Shellwords.split(p.to_s) }
+    end
 
     def flags(cmd)
       suffix = SecureRandom.alphanumeric(4)

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '2.19.0'
+  VERSION = '2.19.1'
 end


### PR DESCRIPTION
## What

- Parse YAML `go:` parameter strings into shell-style argv words before spawning the process.
- Preserve no-shell process execution while restoring compatibility with legacy `go-service` arguments like `-i file:.config/server.yml`.
- Document the parameter behavior, add a Cucumber regression scenario, and bump the gem version to 2.19.1.

## Why

- PR #898 changed process execution to argv form, which made existing single-string `go:` parameters pass through as one argument and broke Go flag parsing.
- Splitting parameter strings with `Shellwords` keeps existing configuration usable without reintroducing shell interpretation.
- Pre-PR review found no blocking issues or security findings.

## Testing

- `make lint` - passed
- `make features` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
