### PR TITLE
feat(go): separate command and argv executable builders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ of dependencies.
 
 Public entry point: `lib/nonnative.rb`.
 
-Main API: `configure`, `start`, `stop`, `clear`, `reset`, `pool`.
+Main API: `configure`, `start`, `stop`, `clear`, `reset`, `pool`,
+`go_argv`, `go_command`.
 
 Configuration is `Nonnative::Configuration`, built with
 `config.process`, `config.server`, `config.service`, or
@@ -81,7 +82,8 @@ Config rules:
 
 - YAML config is loaded as data only via `Nonnative::ConfigurationFile`; ERB is not evaluated and arbitrary Ruby object tags are rejected
 - Runner `host` and nested `proxy.host` default to `127.0.0.1`; use explicit `0.0.0.0` only when external access is intended
-- Process `command` can be a legacy shell string or an argv array; prefer argv arrays for new config, and `go:` config builds argv internally
+- Process `command` can be a legacy shell string or an argv array; prefer argv arrays for new config, and `go:` config builds argv internally with `Nonnative.go_argv`
+- Use `Nonnative.go_argv` for no-shell Go executable argv entries and `Nonnative.go_command` only when a caller needs Ruby shell-style command string spawning
 - YAML services belong under `services:`, not `processes:`
 - There is no top-level `config.wait`; `wait` is per runner
 - Programmatic service config uses `config.service do |s| ... end`, so use `s.host` / `s.port`
@@ -108,6 +110,7 @@ Limitations:
 - Lifecycle: `lib/nonnative.rb`, `lib/nonnative/pool.rb`
 - Readiness/timeouts: `lib/nonnative/port.rb`, `lib/nonnative/timeout.rb`
 - Process lifecycle: `lib/nonnative/process.rb`
+- Go executable command/argv building: `lib/nonnative/go_executable.rb`
 - Proxies: `lib/nonnative/fault_injection_proxy.rb`, `lib/nonnative/socket_pair_factory.rb`
 - Cucumber: `lib/nonnative/cucumber.rb`, `lib/nonnative/startup.rb`, `features/support/env.rb`
 - Config loading: `lib/nonnative/configuration.rb`, `lib/nonnative/configuration_file.rb`, `lib/nonnative/configuration_runner.rb`, `lib/nonnative/configuration_proxy.rb`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (2.19.1)
+    nonnative (2.20.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -781,11 +781,13 @@ Programmatic Go binaries can be configured as normal argv process commands:
 Nonnative.configure do |config|
   config.process do |p|
     p.name = 'go'
-    p.command = -> { ['your_binary', 'sub_command', '--config', 'config.yaml'] }
+    p.command = -> { Nonnative.go_argv(%w[cover], 'reports', 'your_binary', 'sub_command', '-i file:.config/server.yml') }
     p.port = 12_345
   end
 end
 ```
+
+Use `Nonnative.go_argv(...)` when a process should execute without shell interpretation, and `Nonnative.go_command(...)` when a caller needs a command string for Ruby's shell-style `spawn` behavior.
 
 YAML `go:` configuration is for Go test binaries compiled with `go test -c`. It builds argv entries in this order: executable, optional `-test.*` profiling/trace/coverage flags, command, then parameters. Parameter strings are parsed into argv words with shell-style quoting, but the argv entries are executed without shell interpretation.
 

--- a/features/command.feature
+++ b/features/command.feature
@@ -2,8 +2,8 @@
 Feature: Command
   Verify commands are formatted correctly when they run.
 
-  Scenario: Go command with parameters
-    When I create a go command with:
+  Scenario: Go argv with parameters
+    When I create a go argv with:
       | output     | reports          |
       | executable | thisshouldbelong |
       | command    | server           |
@@ -14,8 +14,8 @@ Feature: Command
       | command    | server           |
       | parameters | --level=info     |
 
-  Scenario: Go command with shell-style parameter words
-    When I create a go command with:
+  Scenario: Go argv with shell-style parameter words
+    When I create a go argv with:
       | output     | reports                    |
       | executable | thisshouldbelong           |
       | command    | server                     |
@@ -26,8 +26,20 @@ Feature: Command
       | command    | server                     |
       | parameters | -i,file:.config/server.yml |
 
-  Scenario: Go command without parameters
-    When I create a go command with:
+  Scenario: Go command string
+    When I create a go command string with:
+      | output     | reports                    |
+      | executable | thisshouldbelong           |
+      | command    | client                     |
+      | parameters | -i,file:.config/client.yml |
+    Then I should have a valid go command string with:
+      | output     | reports                    |
+      | executable | thisshouldbelong           |
+      | command    | client                     |
+      | parameters | -i,file:.config/client.yml |
+
+  Scenario: Go argv without parameters
+    When I create a go argv with:
       | output     | reports          |
       | executable | thisshouldbelong |
       | command    | server           |

--- a/features/step_definitions/command_steps.rb
+++ b/features/step_definitions/command_steps.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
-When('I create a go command with:') do |table|
+When('I create a go argv with:') do |table|
   rows = table.rows_hash
   params = rows['parameters']
   params = nil if params == ''
 
-  @exec_path = Nonnative.go_executable_args([], rows['output'], rows['executable'], rows['command'], params)
+  @exec_path = Nonnative.go_argv([], rows['output'], rows['executable'], rows['command'], params)
+end
+
+When('I create a go command string with:') do |table|
+  rows = table.rows_hash
+  params = rows['parameters']
+  params = params.split(',') unless params == ''
+
+  @exec_path = Nonnative.go_command([], rows['output'], rows['executable'], rows['command'], *params)
 end
 
 When('I load the go configuration') do
@@ -19,6 +27,11 @@ end
 Then('I should have a valid go command argv with:') do |table|
   expect(@exec_path).to be_an(Array)
   expect_valid_go_command(table, @exec_path)
+end
+
+Then('I should have a valid go command string with:') do |table|
+  expect(@exec_path).to be_a(String)
+  expect_valid_go_command(table, Shellwords.split(@exec_path))
 end
 
 def expect_valid_go_command(table, parts)

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -94,7 +94,7 @@ require 'nonnative/close_all_socket_pair'
 require 'nonnative/delay_socket_pair'
 require 'nonnative/invalid_data_socket_pair'
 require 'nonnative/socket_pair_factory'
-require 'nonnative/go_command'
+require 'nonnative/go_executable'
 require 'nonnative/cucumber'
 require 'nonnative/header'
 
@@ -154,9 +154,23 @@ module Nonnative
       File.readlines(path).select { |l| predicate.call(l) }
     end
 
+    # Builds a Go test executable command string with optional profiling/trace/coverage flags.
+    #
+    # Use this when passing a command string directly to `spawn`.
+    #
+    # @param tools [Array<String>] enabled tool names (e.g. `["prof", "trace", "cover"]`)
+    # @param output [String] directory where outputs should be written
+    # @param exec [String] the test binary (or wrapper) to execute
+    # @param cmd [String] the command argument passed to the test binary
+    # @param params [Array<String>] extra parameter strings for the command
+    # @return [String] executable command string
+    def go_command(tools, output, exec, cmd, *params)
+      Nonnative::GoExecutable.new(tools, exec, output).command(cmd, *params)
+    end
+
     # Builds a Go test executable argv array with optional profiling/trace/coverage flags.
     #
-    # This is used when process configuration specifies a `go` section.
+    # Use this when passing argv entries directly to `spawn`.
     #
     # @param tools [Array<String>] enabled tool names (e.g. `["prof", "trace", "cover"]`)
     # @param output [String] directory where outputs should be written
@@ -164,8 +178,8 @@ module Nonnative
     # @param cmd [String] the command argument passed to the test binary
     # @param params [Array<String>] extra parameter strings for the command
     # @return [Array<String>] executable argv entries
-    def go_executable_args(tools, output, exec, cmd, *params)
-      Nonnative::GoCommand.new(tools, exec, output).executable_args(cmd, *params)
+    def go_argv(tools, output, exec, cmd, *params)
+      Nonnative::GoExecutable.new(tools, exec, output).argv(cmd, *params)
     end
 
     # Returns an HTTP client for common health/readiness endpoints.

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -141,7 +141,7 @@ module Nonnative
         params = go.parameters || []
         tools = go.tools || []
 
-        -> { Nonnative.go_executable_args(tools, go.output, go.executable, go.command, *params) }
+        -> { Nonnative.go_argv(tools, go.output, go.executable, go.command, *params) }
       else
         -> { process.command }
       end

--- a/lib/nonnative/go_executable.rb
+++ b/lib/nonnative/go_executable.rb
@@ -19,15 +19,16 @@ module Nonnative
   #
   # If `tools` is `nil` or empty, all tools (`prof`, `trace`, `cover`) are enabled.
   #
-  # Parameter strings are parsed into argv words using shell-style quoting, then executed without a shell.
+  # Parameter strings are parsed into argv words using shell-style quoting.
   #
   # @example
-  #   cmd = Nonnative::GoCommand.new(%w[prof cover], './svc.test', 'reports')
-  #   cmd.executable_args('serve', '--config', 'config.yaml')
+  #   executable = Nonnative::GoExecutable.new(%w[prof cover], './svc.test', 'reports')
+  #   executable.argv('serve', '--config', 'config.yaml')
   #   # => ["./svc.test", "-test.cpuprofile=...", "-test.coverprofile=...", "serve", "--config", "config.yaml"]
   #
-  # @see Nonnative.go_executable_args
-  class GoCommand
+  # @see Nonnative.go_command
+  # @see Nonnative.go_argv
+  class GoExecutable
     # @param tools [Array<String>, nil] tool names to enable (see class docs)
     # @param exec [String] path to the compiled Go test binary
     # @param output [String] output directory for generated files
@@ -44,8 +45,17 @@ module Nonnative
     # @param cmd [String] command/sub-command argument passed to the Go test binary
     # @param params [Array<String>] additional parameter strings passed after `cmd`
     # @return [Array<String>] argv entries to execute
-    def executable_args(cmd, *params)
+    def argv(cmd, *params)
       [exec, *flags(cmd), cmd, *parameter_args(params)]
+    end
+
+    # Returns an executable command string including enabled `-test.*` flags.
+    #
+    # @param cmd [String] command/sub-command argument passed to the Go test binary
+    # @param params [Array<String>] additional parameter strings passed after `cmd`
+    # @return [String] the full command to execute
+    def command(cmd, *params)
+      Shellwords.join(argv(cmd, *params))
     end
 
     private

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '2.19.1'
+  VERSION = '2.20.0'
 end


### PR DESCRIPTION
## What

- Replace the old executable helper names with `Nonnative.go_argv(...)` for argv execution and `Nonnative.go_command(...)` for command-string execution.
- Rename the internal builder from `Nonnative::GoCommand` to `Nonnative::GoExecutable` and load it from `nonnative/go_executable`.
- Update YAML `go:` configuration to use the argv builder, refresh README examples, cover both public helper shapes in Cucumber, and bump the gem version to 2.20.0.

## Why

- The public API now makes the execution shape explicit instead of hiding string-vs-argv behavior behind ambiguous executable helper names.
- Managed configuration keeps using argv entries so process startup avoids shell interpretation, while callers that need Ruby command-string spawn behavior can use `go_command` deliberately.
- This is an intentional breaking rename from `go_executable` / `go_executable_args`.
- Pre-PR review found no blocking issues or security findings.

## Testing

- `make lint` - passed
- `make features` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
