### PR TITLE
feat(cucumber): match service unavailable responses case-insensitively

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (2.20.0)
+    nonnative (2.21.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -35,7 +35,7 @@ When('I send a {string} request') do |name|
 end
 
 When('the health endpoint reports service unavailable') do
-  Nonnative::Features::Application.health_body = "Service Unavailable\n"
+  Nonnative::Features::Application.health_body = "http: service unavailable\n"
   Nonnative::Features::Application.health_status = 503
 end
 

--- a/lib/nonnative/cucumber.rb
+++ b/lib/nonnative/cucumber.rb
@@ -88,7 +88,7 @@ module Nonnative
     end
 
     module LifecycleSteps
-      SERVICE_UNAVAILABLE = 'Service Unavailable'
+      SERVICE_UNAVAILABLE = 'service unavailable'
 
       def install_state_steps
         install_start_step
@@ -126,11 +126,12 @@ module Nonnative
         opts = observability_options
 
         Then('I should see {string} as unhealthy') do |service|
+          service = service.downcase
           wait_for { Nonnative.observability.health(opts).code }.to eq(503)
           wait_for { Nonnative.observability.health(opts).body }.to satisfy do |body|
-            body = body.to_s.strip
+            body = body.to_s.strip.downcase
 
-            body == SERVICE_UNAVAILABLE || body.include?(service)
+            body.include?(SERVICE_UNAVAILABLE) || body.include?(service)
           end
         end
       end
@@ -139,11 +140,12 @@ module Nonnative
         opts = observability_options
 
         Then('I should see {string} as healthy') do |service|
+          service = service.downcase
           wait_for { Nonnative.observability.health(opts).code }.to eq(200)
           wait_for { Nonnative.observability.health(opts).body }.to satisfy do |body|
-            body = body.to_s.strip
+            body = body.to_s.strip.downcase
 
-            body != SERVICE_UNAVAILABLE && !body.include?(service)
+            !body.include?(SERVICE_UNAVAILABLE) && !body.include?(service)
           end
         end
       end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '2.20.0'
+  VERSION = '2.21.0'
 end


### PR DESCRIPTION
## What

- Normalize Cucumber health response assertions to lowercase before checking service-unavailable and service-name substrings.
- Update the server observability fixture to exercise the new `http: service unavailable` response body.
- Bump the gem version metadata to 2.21.0.

## Why

- Health checks can now surface prefixed lowercase HTTP service-unavailable bodies, so the matcher needs to tolerate casing and surrounding text.
- No docs changed because the public Cucumber step text and Ruby API remain unchanged.

## Testing

- `bundle exec cucumber features/server_observability.feature` - passed
- `make lint` - passed
- `make features` - passed
