### PR TITLE
test(feature): cover lifecycle and configuration gaps

### DIFF
--- a/features/benchmark.feature
+++ b/features/benchmark.feature
@@ -19,6 +19,7 @@ Feature: Benchmark
     Given I configure the system programmatically with a no op server
     When I attempt to start the system
     Then starting the system should raise an error
+    And starting the system should raise an error containing "though did not respond in time"
 
   @manual
   Scenario: Start nonnative with a start error will rollback started runners
@@ -39,6 +40,7 @@ Feature: Benchmark
     When I start the system
     And I attempt to stop the system
     Then stopping the system should raise an error
+    And stopping the system should raise an error containing "though did not respond in time"
 
   Scenario: Stop nonnative with a stop error will still stop later runners
     Given I configure the system programmatically with a stop error server

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -11,6 +11,10 @@ Feature: Configuration loading
     Then the configured service "service_1" should use host "127.0.0.1" and port 20006
     And the configured service "service_1" proxy should use host "127.0.0.1" and port 30000
 
+  Scenario: YAML maps proxy options
+    Given I load a temporary configuration with proxy options
+    Then the configured service "service_1" proxy option "delay" should be 5
+
   Scenario: Server YAML class entries resolve to server implementations
     Given I load a temporary configuration with a server entry
     Then the configured server "server_1" should use class "Nonnative::Features::TCPServer"
@@ -32,3 +36,12 @@ Feature: Configuration loading
   Scenario: YAML configuration rejects arbitrary Ruby objects
     When I attempt to load a temporary configuration with a Ruby object tag
     Then loading the configuration should fail with a YAML safety error
+
+  Scenario Outline: YAML configuration rejects malformed documents
+    When I attempt to load a temporary configuration with "<kind>" YAML
+    Then loading the configuration should fail with an argument error containing "<message>"
+
+    Examples:
+      | kind         | message                     |
+      | scalar root  | must contain a YAML mapping |
+      | syntax error | YAML syntax error occurred  |

--- a/features/lifecycle.feature
+++ b/features/lifecycle.feature
@@ -52,6 +52,10 @@ Feature: Lifecycle
     When I start a pool with a failing unnamed service
     Then the lifecycle errors should include "Start failed for Nonnative::Features::FailingService: StandardError - boom on service start"
 
+  Scenario: Pool collects service stop lifecycle errors for unnamed services
+    When I stop a pool with a failing unnamed service
+    Then the lifecycle errors should include "Stop failed for Nonnative::Features::FailingService: StandardError - boom on service stop"
+
   Scenario: Pool collects readiness errors for unnamed runners
     When I start a pool with a failing unnamed port check
     Then the lifecycle errors should include "Readiness check failed for Nonnative::Features::FailingRunner: StandardError - boom on readiness"

--- a/features/processes.feature
+++ b/features/processes.feature
@@ -33,6 +33,20 @@ Feature: Process runners
     Then I should receive a TCP "test" response from the process
     And the argv process shell side effect should not happen
 
+  Scenario: Legacy string process commands invoke the shell
+    Given I configure the system programmatically with a shell string process
+    And I start the system
+    When I send "test" with the TCP client "shell_string_process" to the process
+    Then I should receive a TCP "test" response from the process
+    And the shell string process side effect should happen
+
+  Scenario: Processes without a stop signal use the default signal
+    Given I configure the system programmatically with a process that has no stop signal
+    And I start the system
+    When I attempt to stop the system
+    Then stopping the system should not raise an error
+    And the port "12414" should be closed
+
   Scenario: Explicit process environment overrides the parent environment
     Given the parent environment variable "STRING" is "parent"
     When I start a process runner with environment "STRING" set to "configured"
@@ -70,6 +84,7 @@ Feature: Process runners
     And I set the proxy for process 'start_1' to 'invalid_data'
     When I send "test" with the TCP client 'start_1' to the process
     Then I should receive a invalid data that is not "test" for client response with TCP
+    And I should see a log entry of "Received line: 'test'" for process 'start_1'
 
   @proxy
   Scenario: Looking up a missing process proxy fails

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -36,6 +36,26 @@ Given('I load a temporary configuration with split service and proxy endpoints')
   YAML
 end
 
+Given('I load a temporary configuration with proxy options') do
+  load_temporary_configuration(<<~YAML)
+    version: "1.0"
+    name: test
+    url: http://localhost:4567
+    log: test/reports/nonnative.log
+    services:
+      - name: service_1
+        host: 127.0.0.1
+        port: 20006
+        proxy:
+          kind: fault_injection
+          host: 127.0.0.1
+          port: 30000
+          log: test/reports/proxy_service_1.log
+          options:
+            delay: 5
+  YAML
+end
+
 Given('I load a temporary configuration with a server entry') do
   load_temporary_configuration(<<~YAML)
     version: "1.0"
@@ -108,6 +128,13 @@ When('I attempt to load a temporary configuration with a Ruby object tag') do
   end
 end
 
+When('I attempt to load a temporary configuration with {string} YAML') do |kind|
+  @configuration_error = nil
+  capture_result(:@configuration_result, :@configuration_error) do
+    load_temporary_configuration(malformed_yaml(kind))
+  end
+end
+
 Then('the configuration should contain {int} service entry and {int} process entries') do |services, processes|
   expect(Nonnative.configuration.services.size).to eq(services)
   expect(Nonnative.configuration.processes.size).to eq(processes)
@@ -125,6 +152,12 @@ Then('the configured service {string} proxy should use host {string} and port {i
 
   expect(service.proxy.host).to eq(host)
   expect(service.proxy.port).to eq(port)
+end
+
+Then('the configured service {string} proxy option {string} should be {int}') do |name, option, value|
+  service = configured_service(name)
+
+  expect(service.proxy.options[option.to_sym]).to eq(value)
 end
 
 Then('the configured server {string} should use class {string}') do |name, klass|
@@ -163,9 +196,25 @@ Then('loading the configuration should fail with a YAML safety error') do
   expect(@configuration_error).to be_a(Psych::DisallowedClass)
 end
 
+Then('loading the configuration should fail with an argument error containing {string}') do |message|
+  expect(@configuration_error).to be_a(ArgumentError)
+  expect(@configuration_error.message).to include(message)
+end
+
 def load_temporary_configuration(contents)
   path = "test/reports/#{SecureRandom.hex(4)}.yml"
   File.write(path, contents)
 
   load_configuration(path)
+end
+
+def malformed_yaml(kind)
+  case kind
+  when 'scalar root'
+    'not a mapping'
+  when 'syntax error'
+    "name: [unterminated\n"
+  else
+    raise ArgumentError, "Unknown malformed YAML kind '#{kind}'"
+  end
 end

--- a/features/step_definitions/lifecycle_steps.rb
+++ b/features/step_definitions/lifecycle_steps.rb
@@ -40,6 +40,12 @@ When('I start a pool with a failing unnamed service') do
   ).start
 end
 
+When('I stop a pool with a failing unnamed service') do
+  @lifecycle_errors = build_pool(
+    services: [Nonnative::Features::FailingService.new(stop_error: 'boom on service stop')]
+  ).stop
+end
+
 When('I start a pool with ordered services, servers, and processes') do
   @lifecycle_events = []
   @lifecycle_errors = build_ordered_pool(@lifecycle_events).start
@@ -135,6 +141,10 @@ end
 Then('stopping the system should raise an error containing:') do |table|
   expect(@stop_error).to be_a(Nonnative::StopError)
   table.raw.flatten.each { |message| expect(@stop_error.message).to include(message) }
+end
+
+Then('stopping the system should not raise an error') do
+  expect(@stop_error).to be_nil
 end
 
 Then('the lifecycle errors should include {string}') do |message|

--- a/features/step_definitions/processes_steps.rb
+++ b/features/step_definitions/processes_steps.rb
@@ -36,6 +36,38 @@ Given('I configure the system programmatically with an argv process') do
   end
 end
 
+Given('I configure the system programmatically with a shell string process') do
+  @shell_string_side_effect_path = "test/reports/#{SecureRandom.hex(4)}-shell-string"
+  configure_with_defaults do |config|
+    config.process do |process|
+      process.name = 'shell_string_process'
+      process.command = lambda {
+        "printf configured > #{@shell_string_side_effect_path}; exec features/support/bin/start 12413"
+      }
+      process.timeout = 5
+      process.wait = 0.1
+      process.host = '127.0.0.1'
+      process.port = 12_413
+      process.log = 'test/reports/12_413.log'
+      process.signal = 'INT'
+    end
+  end
+end
+
+Given('I configure the system programmatically with a process that has no stop signal') do
+  configure_with_defaults do |config|
+    config.process do |process|
+      process.name = 'default_signal_process'
+      process.command = -> { ['features/support/bin/start', '12414'] }
+      process.timeout = 5
+      process.wait = 0.1
+      process.host = '127.0.0.1'
+      process.port = 12_414
+      process.log = 'test/reports/12_414.log'
+    end
+  end
+end
+
 Given('the parent environment variable {string} is {string}') do |name, value|
   @previous_environment ||= {}
   @previous_environment[name] = ENV.fetch(name, nil)
@@ -91,6 +123,10 @@ Then('the argv process shell side effect should not happen') do
   expect(File.exist?(@argv_side_effect_path)).to be(false)
 end
 
+Then('the shell string process side effect should happen') do
+  expect(File.read(@shell_string_side_effect_path)).to eq('configured')
+end
+
 Then('the YAML argv process shell side effect should not happen') do
   expect(File.exist?(@yaml_argv_side_effect_path)).to be(false)
 end
@@ -120,5 +156,7 @@ After do
 end
 
 Then('I should receive a invalid data that is not {string} for client response with TCP') do |message|
+  expect(@response).to be_a(String)
+  expect(@response).not_to be_empty
   expect(@response).not_to eq(message)
 end


### PR DESCRIPTION
## What

- Adds Cucumber coverage for legacy string process commands, default process stop signals, invalid-data proxy behavior, YAML proxy options, malformed YAML diagnostics, service stop lifecycle errors, and benchmark timeout messages.
- Keeps the change scoped to test coverage; runtime behavior is unchanged.

## Why

- These scenarios protect compatibility and diagnostics that were previously weakly asserted or absent.
- Stronger coverage reduces the chance of downstream regressions in process startup, proxy fault injection, configuration loading, and lifecycle error reporting.

## Testing

- `make features` - passed
- `make benchmarks` - passed
- `make lint` - passed
