### PR TITLE
docs(style): move cucumber helper assertions to support

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ end
 
 ##### Proxy
 
-The system allows you to define a http proxy for external systems, e.g api.github.com
+The system allows you to define an HTTP proxy for external systems, e.g. `api.github.com`.
 
 Define your server:
 
@@ -539,14 +539,14 @@ end
 
 #### Proxies
 
-We allow different proxies to be configured. These proxies can be used to simulate all kind of situations. The proxies that can be configured are:
+These proxies can simulate different situations. Available proxy kinds are:
 
 - `none` (this is the default)
 - `fault_injection`
 
 For `fault_injection`, keep the runner `host`/`port` as the client-facing endpoint and use nested `proxy.host`/`proxy.port` for the upstream target behind the proxy.
 
-##### Proxies Processes
+##### Process Proxies
 
 Add this to an existing process configuration:
 
@@ -598,7 +598,7 @@ processes:
         delay: 5
 ```
 
-##### Proxies Servers
+##### Server Proxies
 
 Add this to an existing server configuration:
 
@@ -650,7 +650,7 @@ servers:
         delay: 5
 ```
 
-##### Proxies Services
+##### Service Proxies
 
 Add this to an existing service configuration:
 
@@ -711,7 +711,7 @@ The `fault_injection` proxy allows you to simulate failures by injecting them. W
 Clients connect to the runner `host`/`port`, while the proxy forwards traffic to nested `proxy.host`/`proxy.port`.
 
 - `close_all` - Closes the socket as soon as it connects.
-- `delay` - This delays the communication between the connection. Default is 2 secs can be configured through options.
+- `delay` - Delays traffic on the connection. Defaults to 2 seconds and can be configured through options.
 - `invalid_data` - This takes the input and rearranges it to produce invalid data.
 
 ###### Fault Injection Processes

--- a/features/benchmark.feature
+++ b/features/benchmark.feature
@@ -1,6 +1,6 @@
 @benchmark @slow @clear
 Feature: Benchmark
-  Allows us to check that start and stop responds in adequate time
+  Allows us to check that start and stop complete in adequate time
 
   @config
   @manual

--- a/features/configs/servers.yml
+++ b/features/configs/servers.yml
@@ -24,7 +24,6 @@ servers:
       port: 20001
       log: test/reports/proxy_tcp_server_2.log
       wait: 1
-      servers:
   - name: http_proxy_server
     class: Nonnative::Features::HTTPProxyServer
     timeout: 3

--- a/features/http_proxies.feature
+++ b/features/http_proxies.feature
@@ -3,10 +3,10 @@ Feature: HTTP proxies
   Proxy HTTP requests through local and configured proxy servers.
 
   Scenario Outline: The local HTTP proxy forwards <verb> requests end to end
-    Given I configure the system programmatically with a local http proxy server
+    Given I configure the system programmatically with a local HTTP proxy server
     And I start the system
-    When I send a "<verb>" request with body "Hello World!" to the local http proxy server
-    Then I should receive the "<verb>" request details from the local http proxy server
+    When I send a "<verb>" request with body "Hello World!" to the local HTTP proxy server
+    Then I should receive the "<verb>" request details from the local HTTP proxy server
 
     Examples:
       | verb   |
@@ -19,8 +19,8 @@ Feature: HTTP proxies
   Scenario Outline: The configured HTTP proxy returns a <kind> response
     Given I configure the system through configuration with servers
     And I start the system
-    When I send a <kind> message to the http proxy server
-    Then I should receive a <kind> response from the http proxy server
+    When I send a <kind> message to the HTTP proxy server
+    Then I should receive a <kind> response from the HTTP proxy server
 
     Examples:
       | kind       |

--- a/features/processes.feature
+++ b/features/processes.feature
@@ -83,7 +83,7 @@ Feature: Process runners
     And I start the system
     And I set the proxy for process 'start_1' to 'invalid_data'
     When I send "test" with the TCP client 'start_1' to the process
-    Then I should receive a invalid data that is not "test" for client response with TCP
+    Then I should receive an invalid data response that is not "test" with TCP
     And I should see a log entry of "Received line: 'test'" for process 'start_1'
 
   @proxy

--- a/features/servers.feature
+++ b/features/servers.feature
@@ -20,20 +20,20 @@ Feature: Servers
   Scenario: HTTP servers return hello responses
     Given I configure the system programmatically with servers
     And I start the system
-    When I send a message with the http client to the servers
-    Then I should receive a http "Hello World!" response
+    When I send a message with the HTTP client to the servers
+    Then I should receive an HTTP "Hello World!" response
 
   Scenario: HTTP servers return not found for unknown routes
     Given I configure the system programmatically with servers
     And I start the system
-    When I send a not found message with the http client to the servers
-    Then I should receive a http not found response
+    When I send a not found message with the HTTP client to the servers
+    Then I should receive an HTTP not found response
 
   Scenario: gRPC servers greet clients
     Given I configure the system programmatically with servers
     And I start the system
-    When I send a message with the grpc client to the servers
-    Then I should receive a grpc "Hello World!" response
+    When I send a message with the gRPC client to the servers
+    Then I should receive a gRPC "Hello World!" response
 
   Scenario: The health endpoint reports the servers as healthy
     Given I configure the system programmatically with servers
@@ -79,7 +79,7 @@ Feature: Servers
     And I start the system
     And I set the proxy for server 'http_server_1' to '<state>'
     When I request hello over HTTP
-    Then I should receive a <failure> error for hello response with HTTP
+    Then I should receive the <failure> error for hello response with HTTP
 
     Examples:
       | state        | failure      |
@@ -92,7 +92,7 @@ Feature: Servers
     And I start the system
     And I set the proxy for server 'grpc_server_1' to '<state>'
     When I <request>
-    Then I should receive a <failure> error for being greeted with gRPC
+    Then I should receive the <failure> error for being greeted with gRPC
 
     Examples:
       | state        | request                               | failure      |

--- a/features/step_definitions/benchmark_steps.rb
+++ b/features/step_definitions/benchmark_steps.rb
@@ -29,12 +29,5 @@ Then('stopping the system should happen within an adequate time') do
 end
 
 Then('the port {string} should be closed') do |port|
-  wait_for do
-    socket = TCPSocket.new('127.0.0.1', port.to_i)
-    socket.close
-
-    false
-  rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
-    true
-  end.to eq(true)
+  wait_for { port_closed?(port.to_i) }.to eq(true)
 end

--- a/features/step_definitions/command_steps.rb
+++ b/features/step_definitions/command_steps.rb
@@ -26,43 +26,10 @@ end
 
 Then('I should have a valid go command argv with:') do |table|
   expect(@exec_path).to be_an(Array)
-  expect_valid_go_command(table, @exec_path)
+  expect(@exec_path).to match_go_command(table)
 end
 
 Then('I should have a valid go command string with:') do |table|
   expect(@exec_path).to be_a(String)
-  expect_valid_go_command(table, Shellwords.split(@exec_path))
-end
-
-def expect_valid_go_command(table, parts)
-  rows = table.rows_hash
-  params = rows['parameters']
-  output = rows['output']
-  exec = rows['executable']
-  cmd = rows['command']
-
-  expect(parts.first).to eq(exec)
-  parts = expect_go_command_parts(parts, cmd, params)
-
-  expect_go_command_flags(parts, output, exec, cmd)
-end
-
-def expect_go_command_parts(parts, cmd, params)
-  return expect_go_command_without_params(parts, cmd) if params == ''
-
-  parameters = params.split(',')
-  expect(parts.last(parameters.length)).to eq(parameters)
-  expect(parts[-(parameters.length + 1)]).to eq(cmd)
-
-  parts[1...-(parameters.length + 1)]
-end
-
-def expect_go_command_without_params(parts, cmd)
-  expect(parts.last).to eq(cmd)
-
-  parts[1..-2]
-end
-
-def expect_go_command_flags(parts, output, exec, cmd)
-  parts.each { |p| expect(p).to include("#{output}/#{exec}-#{cmd}") }
+  expect(Shellwords.split(@exec_path)).to match_go_command(table)
 end

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -200,21 +200,3 @@ Then('loading the configuration should fail with an argument error containing {s
   expect(@configuration_error).to be_a(ArgumentError)
   expect(@configuration_error.message).to include(message)
 end
-
-def load_temporary_configuration(contents)
-  path = "test/reports/#{SecureRandom.hex(4)}.yml"
-  File.write(path, contents)
-
-  load_configuration(path)
-end
-
-def malformed_yaml(kind)
-  case kind
-  when 'scalar root'
-    'not a mapping'
-  when 'syntax error'
-    "name: [unterminated\n"
-  else
-    raise ArgumentError, "Unknown malformed YAML kind '#{kind}'"
-  end
-end

--- a/features/step_definitions/lifecycle_steps.rb
+++ b/features/step_definitions/lifecycle_steps.rb
@@ -152,7 +152,7 @@ Then('the lifecycle errors should include {string}') do |message|
 end
 
 Then('the lifecycle errors should be empty') do
-  expect(@lifecycle_errors).to eq([])
+  expect(@lifecycle_errors).to be_empty
 end
 
 Then('the lifecycle order should be:') do |table|
@@ -190,84 +190,4 @@ end
 
 After do
   cleanup_lingering_processes
-end
-
-def build_pool(services: [], servers: [], processes: [])
-  Nonnative::Features::SeededPool.new(Nonnative::Configuration.new, services:, servers:, processes:)
-end
-
-def add_lingering_process(config, name, port)
-  config.process do |process|
-    process.name = name
-    process.command = -> { ['features/support/bin/start', port.to_s, 'linger'] }
-    process.timeout = 2
-    process.wait = 0.1
-    process.host = '127.0.0.1'
-    process.port = port
-    process.log = "test/reports/#{port}.log"
-    process.signal = 'INT'
-  end
-end
-
-def add_fast_exit_process(config, name, port)
-  config.process do |process|
-    process.name = name
-    process.command = -> { [RbConfig.ruby, '-e', 'exit 0'] }
-    process.timeout = 1
-    process.wait = 0.1
-    process.host = '127.0.0.1'
-    process.port = port
-    process.log = "test/reports/#{port}.log"
-    process.signal = 'INT'
-  end
-end
-
-def cleanup_lingering_processes
-  @lingering_processes&.each { |name| cleanup_lingering_process(name) }
-end
-
-def cleanup_lingering_process(name)
-  pid = Nonnative.pool&.process_by_name(name)&.instance_variable_get(:@pid)
-  return unless pid
-
-  Process.kill('KILL', pid)
-  Process.wait(pid)
-rescue Nonnative::NotFoundError, Errno::ESRCH, Errno::ECHILD
-  nil
-end
-
-def build_ordered_pool(events)
-  build_pool(
-    services: [Nonnative::Features::RecordingService.new(name: 'service_1', events:)],
-    servers: [[
-      Nonnative::Features::RecordingRunner.new(name: 'server_1', events:),
-      Nonnative::Features::PassingPort.new
-    ]],
-    processes: [[
-      Nonnative::Features::RecordingRunner.new(name: 'process_1', events:),
-      Nonnative::Features::PassingPort.new
-    ]]
-  )
-end
-
-def configure_for_clear(log:, url:)
-  Nonnative.configure do |config|
-    config.name = 'test'
-    config.url = url
-    config.log = log
-  end
-end
-
-def observability_host(client)
-  client.send(:host)
-end
-
-def run_subprocess(script)
-  @subprocess_stdout, @subprocess_stderr, @subprocess_status = Open3.capture3(
-    RbConfig.ruby,
-    '-Ilib',
-    '-e',
-    script,
-    chdir: Dir.pwd
-  )
 end

--- a/features/step_definitions/processes_steps.rb
+++ b/features/step_definitions/processes_steps.rb
@@ -155,7 +155,7 @@ After do
   end
 end
 
-Then('I should receive a invalid data that is not {string} for client response with TCP') do |message|
+Then('I should receive an invalid data response that is not {string} with TCP') do |message|
   expect(@response).to be_a(String)
   expect(@response).not_to be_empty
   expect(@response).not_to eq(message)

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -8,7 +8,7 @@ Given('I configure the system through configuration with servers') do
   load_configuration('features/configs/servers.yml')
 end
 
-Given('I configure the system programmatically with a local http proxy server') do
+Given('I configure the system programmatically with a local HTTP proxy server') do
   configure_local_http_proxy_server
 end
 
@@ -16,7 +16,7 @@ When('I send a message with the tcp client to the servers') do
   @responses = %w[tcp_server_1 tcp_server_2].map { |name| tcp_client_for_server(name).request('') }
 end
 
-When('I send a message with the http client to the servers') do
+When('I send a message with the HTTP client to the servers') do
   @responses = %w[http_server_1 http_server_2].flat_map do |name|
     client = http_client_for_server(name)
 
@@ -24,7 +24,7 @@ When('I send a message with the http client to the servers') do
   end
 end
 
-When('I send a message with the grpc client to the servers') do
+When('I send a message with the gRPC client to the servers') do
   @responses = %w[grpc_server_1 grpc_server_2].map do |name|
     grpc_client_for_server(name).say_hello(greeter_request)
   end
@@ -39,7 +39,7 @@ When('the health endpoint reports service unavailable') do
   Nonnative::Features::Application.health_status = 503
 end
 
-When('I send a not found message with the http client to the servers') do
+When('I send a not found message with the HTTP client to the servers') do
   @response = http_client_for_server('http_server_1').not_found
 end
 
@@ -53,7 +53,7 @@ When('I register a custom proxy kind') do
 end
 
 Then('I should get a proxy not found error') do
-  expect(@error).to be_a_kind_of(Nonnative::NotFoundError)
+  expect(@error).to be_a(Nonnative::NotFoundError)
 end
 
 Then('the custom proxy kind should resolve to the custom proxy') do
@@ -64,15 +64,15 @@ Then('the custom proxy kind should resolve to the custom proxy') do
   expect(actual).to eq(Nonnative::Features::CustomProxy)
 end
 
-When('I send a successful message to the http proxy server') do
+When('I send a successful message to the HTTP proxy server') do
   @response = RestClient::Resource.new("http://localhost:#{configured_server('http_proxy_server').port}").get
 end
 
-When('I send a not found message to the http proxy server') do
+When('I send a not found message to the HTTP proxy server') do
   @response = http_client_for_server('http_proxy_server').hello_get
 end
 
-When('I send a {string} request with body {string} to the local http proxy server') do |verb, body|
+When('I send a {string} request with body {string} to the local HTTP proxy server') do |verb, body|
   @response = http_client_for_server('local_http_proxy_server').inspect_request(verb.downcase, body)
 end
 
@@ -92,14 +92,14 @@ When('I greet over gRPC with a short deadline') do
   capture_result { grpc_client_for_server('grpc_server_1', timeout: 1).say_hello(greeter_request) }
 end
 
-Then('I should receive a http {string} response') do |response|
+Then('I should receive an HTTP {string} response') do |response|
   @responses.each do |r|
     expect(r.code).to eq(200)
     expect(r.body).to eq(response.to_json)
   end
 end
 
-Then('I should receive a grpc {string} response') do |response|
+Then('I should receive a gRPC {string} response') do |response|
   @responses.each do |r|
     expect(r.message).to eq(response)
   end
@@ -110,7 +110,7 @@ Then('I should receive a successful {string} response') do |_|
   expect(@response.code).to eq(200)
 end
 
-Then('I should receive a http not found response') do
+Then('I should receive an HTTP not found response') do
   expect(@error).to be_nil
   expect(@response.code).to eq(404)
 end
@@ -119,59 +119,40 @@ Then('I should receive a connection error for metrics response with HTTP') do
   expect(@error).to be_a(StandardError)
 end
 
-Then('I should receive a delay error for hello response with HTTP') do
+Then('I should receive the delay error for hello response with HTTP') do
   expect(@error).to be_a(RestClient::Exceptions::ReadTimeout)
 end
 
-Then('I should receive a invalid data error for hello response with HTTP') do
+Then('I should receive the invalid data error for hello response with HTTP') do
   expect(@error).to be_a(Net::HTTPBadResponse)
 end
 
-Then('I should receive a connection error for being greeted with gRPC') do
+Then('I should receive the connection error for being greeted with gRPC') do
   expect(@error).to be_a(GRPC::Unavailable)
 end
 
-Then('I should receive a delay error for being greeted with gRPC') do
+Then('I should receive the delay error for being greeted with gRPC') do
   expect(@error).to be_a(GRPC::DeadlineExceeded)
 end
 
-Then('I should receive a invalid data error for being greeted with gRPC') do
+Then('I should receive the invalid data error for being greeted with gRPC') do
   expect(@error).to be_a(StandardError)
 end
 
-Then('I should receive a successful response from the http proxy server') do
+Then('I should receive a successful response from the HTTP proxy server') do
   expect(@error).to be_nil
   expect(@response.code).to eq(200)
 end
 
-Then('I should receive a not found response from the http proxy server') do
+Then('I should receive a not found response from the HTTP proxy server') do
   expect(@error).to be_nil
   expect(@response.code).to eq(404)
 end
 
-Then('I should receive the {string} request details from the local http proxy server') do |verb|
+Then('I should receive the {string} request details from the local HTTP proxy server') do |verb|
   body = JSON.parse(@response.body)
 
   expect(@error).to be_nil
   expect(@response.code).to eq(200)
-  expect(body).to include(
-    'method' => verb,
-    'body' => 'Hello World!',
-    'content_type' => 'application/json',
-    'content_length' => '12'
-  )
-  expect(body).to include(expected_inspect_headers(verb))
-end
-
-def expected_inspect_headers(verb)
-  case verb
-  when 'POST'
-    { 'authorization' => Nonnative::Header.auth_basic('test:test').fetch(:authorization) }
-  when 'PUT', 'DELETE'
-    { 'authorization' => Nonnative::Header.auth_bearer('token').fetch(:authorization) }
-  when 'PATCH'
-    { 'user_agent' => Nonnative::Header.http_user_agent('test 1.0').fetch(:user_agent) }
-  else
-    {}
-  end
+  expect(body).to match_inspected_proxy_request(verb, 'Hello World!')
 end

--- a/features/step_definitions/services_steps.rb
+++ b/features/step_definitions/services_steps.rb
@@ -36,7 +36,3 @@ end
 Then('I should have a successful connection') do
   expect(@service).not_to be_closed
 end
-
-def connection_error?(response)
-  response.nil? || response.is_a?(IOError) || response.is_a?(SystemCallError)
-end

--- a/features/support/context.rb
+++ b/features/support/context.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require_relative 'context/scenario_context'
+require_relative 'context/configuration_files'
 require_relative 'context/process_configuration'
 require_relative 'context/server_configuration'
 require_relative 'context/http_proxy_configuration'
 require_relative 'context/service_configuration'
 require_relative 'context/benchmark_configuration'
 require_relative 'context/endpoint_clients'
+require_relative 'context/lifecycle_support'
+require_relative 'context/network_checks'
 
 module Nonnative
   module Features
@@ -17,12 +20,15 @@ module Nonnative
       DEFAULT_VERSION = '1.0'
 
       include ScenarioContext
+      include ConfigurationFiles
       include ProcessConfiguration
       include ServerConfiguration
       include HTTPProxyConfiguration
       include ServiceConfiguration
       include BenchmarkConfiguration
       include EndpointClients
+      include LifecycleSupport
+      include NetworkChecks
     end
   end
 end

--- a/features/support/context/configuration_files.rb
+++ b/features/support/context/configuration_files.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Nonnative
+  module Features
+    module Context
+      module ConfigurationFiles
+        def load_temporary_configuration(contents)
+          path = "test/reports/#{SecureRandom.hex(4)}.yml"
+          File.write(path, contents)
+
+          load_configuration(path)
+        end
+
+        def malformed_yaml(kind)
+          case kind
+          when 'scalar root'
+            'not a mapping'
+          when 'syntax error'
+            "name: [unterminated\n"
+          else
+            raise ArgumentError, "Unknown malformed YAML kind '#{kind}'"
+          end
+        end
+      end
+    end
+  end
+end

--- a/features/support/context/lifecycle_support.rb
+++ b/features/support/context/lifecycle_support.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Nonnative
+  module Features
+    module Context
+      module LifecycleSupport
+        def build_pool(services: [], servers: [], processes: [])
+          Nonnative::Features::SeededPool.new(Nonnative::Configuration.new, services:, servers:, processes:)
+        end
+
+        def add_lingering_process(config, name, port)
+          config.process do |process|
+            process.name = name
+            process.command = -> { ['features/support/bin/start', port.to_s, 'linger'] }
+            process.timeout = 2
+            process.wait = 0.1
+            process.host = '127.0.0.1'
+            process.port = port
+            process.log = "test/reports/#{port}.log"
+            process.signal = 'INT'
+          end
+        end
+
+        def add_fast_exit_process(config, name, port)
+          config.process do |process|
+            process.name = name
+            process.command = -> { [RbConfig.ruby, '-e', 'exit 0'] }
+            process.timeout = 1
+            process.wait = 0.1
+            process.host = '127.0.0.1'
+            process.port = port
+            process.log = "test/reports/#{port}.log"
+            process.signal = 'INT'
+          end
+        end
+
+        def cleanup_lingering_processes
+          @lingering_processes&.each { |name| cleanup_lingering_process(name) }
+        end
+
+        def cleanup_lingering_process(name)
+          pid = Nonnative.pool&.process_by_name(name)&.instance_variable_get(:@pid)
+          return unless pid
+
+          ::Process.kill('KILL', pid)
+          ::Process.wait(pid)
+        rescue Nonnative::NotFoundError, Errno::ESRCH, Errno::ECHILD
+          nil
+        end
+
+        def build_ordered_pool(events)
+          build_pool(
+            services: [Nonnative::Features::RecordingService.new(name: 'service_1', events:)],
+            servers: [[
+              Nonnative::Features::RecordingRunner.new(name: 'server_1', events:),
+              Nonnative::Features::PassingPort.new
+            ]],
+            processes: [[
+              Nonnative::Features::RecordingRunner.new(name: 'process_1', events:),
+              Nonnative::Features::PassingPort.new
+            ]]
+          )
+        end
+
+        def configure_for_clear(log:, url:)
+          Nonnative.configure do |config|
+            config.name = 'test'
+            config.url = url
+            config.log = log
+          end
+        end
+
+        def observability_host(client)
+          client.send(:host)
+        end
+
+        def run_subprocess(script)
+          @subprocess_stdout, @subprocess_stderr, @subprocess_status = Open3.capture3(
+            RbConfig.ruby,
+            '-Ilib',
+            '-e',
+            script,
+            chdir: Dir.pwd
+          )
+        end
+      end
+    end
+  end
+end

--- a/features/support/context/network_checks.rb
+++ b/features/support/context/network_checks.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Nonnative
+  module Features
+    module Context
+      module NetworkChecks
+        def port_closed?(port)
+          socket = TCPSocket.new('127.0.0.1', port)
+          socket.close
+
+          false
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          true
+        end
+
+        def connection_error?(response)
+          response.nil? || response.is_a?(IOError) || response.is_a?(SystemCallError)
+        end
+      end
+    end
+  end
+end

--- a/features/support/go_command_matcher.rb
+++ b/features/support/go_command_matcher.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :match_go_command do |table|
+  match do |parts|
+    rows = table.rows_hash
+    @parameters = rows['parameters']
+    @output = rows['output']
+    @executable = rows['executable']
+    @command = rows['command']
+
+    @actual_parts = parts
+    @flag_parts = go_command_flag_parts(parts)
+
+    first_part_matches?(parts) &&
+      command_parts_match?(parts) &&
+      flags_match?
+  end
+
+  failure_message do
+    "expected #{@actual_parts.inspect} to match Go command " \
+      "#{@executable} #{@command} with parameters #{@parameters.inspect}"
+  end
+
+  def first_part_matches?(parts)
+    parts.first == @executable
+  end
+
+  def command_parts_match?(parts)
+    return command_without_parameters_matches?(parts) if @parameters == ''
+
+    parameter_parts = @parameters.split(',')
+    parts.last(parameter_parts.length) == parameter_parts &&
+      parts[-(parameter_parts.length + 1)] == @command
+  end
+
+  def command_without_parameters_matches?(parts)
+    parts.last == @command
+  end
+
+  def go_command_flag_parts(parts)
+    return parts[1..-2] if @parameters == ''
+
+    parameter_count = @parameters.split(',').length
+    parts[1...-(parameter_count + 1)]
+  end
+
+  def flags_match?
+    @flag_parts.all? { |part| part.include?("#{@output}/#{@executable}-#{@command}") }
+  end
+end

--- a/features/support/grpc_server.rb
+++ b/features/support/grpc_server.rb
@@ -6,9 +6,7 @@ module Nonnative
   module Features
     class GRPCServer < Nonnative::GRPCServer
       def initialize(service)
-        svc = Greeter.new
-
-        super(svc, service)
+        super(Greeter.new, service)
       end
     end
   end

--- a/features/support/inspect_request_matcher.rb
+++ b/features/support/inspect_request_matcher.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :match_inspected_proxy_request do |verb, expected_body|
+  match do |body|
+    @verb = verb
+    @expected_body = expected_body
+    @body = body
+
+    body_matches? && headers_match?
+  end
+
+  failure_message do
+    "expected #{@body.inspect} to match inspected #{@verb} request with body #{@expected_body.inspect}"
+  end
+
+  def body_matches?
+    expected_fields = {
+      'method' => @verb,
+      'body' => @expected_body,
+      'content_type' => 'application/json',
+      'content_length' => @expected_body.length.to_s
+    }
+
+    includes_fields?(expected_fields)
+  end
+
+  def headers_match?
+    includes_fields?(expected_inspect_headers)
+  end
+
+  def includes_fields?(fields)
+    fields.all? { |key, value| @body[key] == value }
+  end
+
+  def expected_inspect_headers
+    case @verb
+    when 'POST'
+      { 'authorization' => Nonnative::Header.auth_basic('test:test').fetch(:authorization) }
+    when 'PUT', 'DELETE'
+      { 'authorization' => Nonnative::Header.auth_bearer('token').fetch(:authorization) }
+    when 'PATCH'
+      { 'user_agent' => Nonnative::Header.http_user_agent('test 1.0').fetch(:user_agent) }
+    else
+      {}
+    end
+  end
+end

--- a/features/support/tcp_client.rb
+++ b/features/support/tcp_client.rb
@@ -8,11 +8,11 @@ module Nonnative
         @port = port
       end
 
-      def request(msg)
-        s = TCPSocket.open(@host, @port)
-        s.puts msg
-        response = s.gets.chomp
-        s.close
+      def request(message)
+        socket = TCPSocket.open(@host, @port)
+        socket.puts message
+        response = socket.gets.chomp
+        socket.close
         response
       rescue StandardError => e
         e

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -123,14 +123,14 @@ module Nonnative
 
     def add_processes(cfg)
       processes = cfg.processes || []
-      processes.each do |fd|
-        process do |d|
-          d.command = command(fd)
-          d.signal = fd.signal
-          d.environment = fd.environment
-          runner_attributes(d, fd)
+      processes.each do |loaded_process|
+        process do |process_config|
+          process_config.command = command(loaded_process)
+          process_config.signal = loaded_process.signal
+          process_config.environment = loaded_process.environment
+          runner_attributes(process_config, loaded_process)
 
-          proxy d, fd.proxy
+          assign_proxy(process_config, loaded_process.proxy)
         end
       end
     end
@@ -149,25 +149,25 @@ module Nonnative
 
     def add_servers(cfg)
       servers = cfg.servers || []
-      servers.each do |fd|
-        server do |s|
-          s.klass = Object.const_get(server_class_name(fd))
-          runner_attributes(s, fd)
+      servers.each do |loaded_server|
+        server do |server_config|
+          server_config.klass = Object.const_get(server_class_name(loaded_server))
+          runner_attributes(server_config, loaded_server)
 
-          proxy s, fd.proxy
+          assign_proxy(server_config, loaded_server.proxy)
         end
       end
     end
 
     def add_services(cfg)
       services = cfg.services || []
-      services.each do |fd|
-        service do |s|
-          s.name = fd.name
-          s.host = fd.host if fd.host
-          s.port = fd.port
+      services.each do |loaded_service|
+        service do |service_config|
+          service_config.name = loaded_service.name
+          service_config.host = loaded_service.host if loaded_service.host
+          service_config.port = loaded_service.port
 
-          proxy s, fd.proxy
+          assign_proxy(service_config, loaded_service.proxy)
         end
       end
     end
@@ -186,20 +186,20 @@ module Nonnative
       runner.log = loaded.log if loaded.respond_to?(:log)
     end
 
-    def proxy(runner, proxy)
-      return unless proxy
+    def assign_proxy(runner, loaded_proxy)
+      return unless loaded_proxy
 
-      p = {
-        kind: proxy.kind,
-        port: proxy.port,
-        log: proxy.log,
-        options: proxy.options
+      proxy_attributes = {
+        kind: loaded_proxy.kind,
+        port: loaded_proxy.port,
+        log: loaded_proxy.log,
+        options: loaded_proxy.options
       }
 
-      p[:host] = proxy.host if proxy.host
-      p[:wait] = proxy.wait if proxy.wait
+      proxy_attributes[:host] = loaded_proxy.host if loaded_proxy.host
+      proxy_attributes[:wait] = loaded_proxy.wait if loaded_proxy.wait
 
-      runner.proxy = p
+      runner.proxy = proxy_attributes
     end
   end
 end

--- a/lib/nonnative/http_proxy_server.rb
+++ b/lib/nonnative/http_proxy_server.rb
@@ -50,9 +50,10 @@ module Nonnative
 
     # Executes the upstream request and returns the response.
     #
-    # @param verb [String] HTTP verb name (e.g. `"get"`)
-    # @param uri [String] upstream URI
-    # @param opts [Hash] RestClient options (e.g. headers)
+    # @param method [Symbol] HTTP verb name (e.g. `:get`)
+    # @param url [String] upstream URL
+    # @param headers [Hash] request headers
+    # @param payload [String, nil] request payload
     # @return [RestClient::Response] response for error statuses, otherwise RestClient return value
     def api_response(method:, url:, headers:, payload: nil)
       options = { method:, url:, headers: }

--- a/lib/nonnative/http_server.rb
+++ b/lib/nonnative/http_server.rb
@@ -66,6 +66,6 @@ module Nonnative
 
     private
 
-    attr_reader :queue, :server
+    attr_reader :server
   end
 end

--- a/lib/nonnative/pool.rb
+++ b/lib/nonnative/pool.rb
@@ -35,7 +35,7 @@ module Nonnative
       errors = []
 
       errors.concat(service_lifecycle(services, :start, :start))
-      [servers, processes].each { |t| errors.concat(process(t, :start, :open?, :start, &)) }
+      [servers, processes].each { |runners| errors.concat(run_lifecycle_checks(runners, :start, :open?, :start, &)) }
 
       errors
     end
@@ -51,7 +51,7 @@ module Nonnative
     def stop(&)
       errors = []
 
-      [processes, servers].each { |t| errors.concat(process(t, :stop, :closed?, :stop, &)) }
+      [processes, servers].each { |runners| errors.concat(run_lifecycle_checks(runners, :stop, :closed?, :stop, &)) }
       errors.concat(service_lifecycle(services, :stop, :stop))
 
       errors
@@ -69,7 +69,9 @@ module Nonnative
     def rollback(&)
       errors = []
 
-      [existing_processes, existing_servers].each { |t| errors.concat(process(t, :stop, :closed?, :stop, &)) }
+      [existing_processes, existing_servers].each do |runners|
+        errors.concat(run_lifecycle_checks(runners, :stop, :closed?, :stop, &))
+      end
       errors.concat(service_lifecycle(existing_services, :stop, :stop))
 
       errors
@@ -177,15 +179,15 @@ module Nonnative
       end
     end
 
-    def process(all, type_method, port_method, action, &)
+    def run_lifecycle_checks(runners, lifecycle_method, port_method, action, &)
       checks = []
       errors = []
 
-      all.each do |type, port|
-        values = type.send(type_method)
-        checks << [type, values, Thread.new { check_port(port, port_method) }]
+      runners.each do |runner, port|
+        values = runner.send(lifecycle_method)
+        checks << [runner, values, Thread.new { check_port(port, port_method) }]
       rescue StandardError => e
-        errors << lifecycle_error(action, type, e)
+        errors << lifecycle_error(action, runner, e)
       end
 
       errors.concat(yield_results(checks, action, &))

--- a/lib/nonnative/socket_pair.rb
+++ b/lib/nonnative/socket_pair.rb
@@ -65,18 +65,18 @@ module Nonnative
       ::TCPSocket.new(proxy.host, proxy.port)
     end
 
-    # Pipes data from `socket1` to `socket2` if `socket1` is readable.
+    # Pipes data from `source_socket` to `destination_socket` when the source is readable.
     #
     # @param ready [Array<Array<IO>>] the result from `select`
-    # @param socket1 [IO] readable side
-    # @param socket2 [IO] writable side
+    # @param source_socket [IO] readable side
+    # @param destination_socket [IO] writable side
     # @return [Boolean] whether the piping loop should terminate
-    def pipe?(ready, socket1, socket2)
-      if ready[0].include?(socket1)
-        data = read(socket1)
+    def pipe?(ready, source_socket, destination_socket)
+      if ready[0].include?(source_socket)
+        data = read(source_socket)
         return true if data.empty?
 
-        write socket2, data
+        write destination_socket, data
       end
 
       false

--- a/nonnative.gemspec
+++ b/nonnative.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Alejandro Falkowski']
   spec.email         = ['alexrfalkowski@gmail.com']
 
-  spec.summary       = 'Allows you to keep using the power of ruby to test other systems'
+  spec.summary       = 'Allows you to keep using the power of Ruby to test other systems'
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/alexfalkowski/nonnative'
   spec.license       = 'MIT'


### PR DESCRIPTION
## What

- Moved Cucumber helper assertions and support utilities out of step definition files and into `features/support` modules and matchers.
- Polished scenario wording, README proxy language, and local Ruby names without changing public runtime behavior.
- Removed an unused HTTP server reader and a stray nested `servers:` key from the server fixture configuration.

## Why

- Keeps step definitions focused on scenario intent while preserving reusable assertion and fixture logic in support files.
- Makes the feature suite easier to scan and maintain as the command, proxy, lifecycle, and network checks grow.
- Reduces small readability rough edges found during the style pass.

## Testing

- `make lint` - passed
- `bundle exec cucumber features/command.feature` - passed
- `bundle exec cucumber features/configuration.feature features/lifecycle.feature features/http_proxies.feature features/services.feature features/benchmark.feature` - passed
- `make features` - passed
- `make benchmarks` - passed
- `git diff --check` - passed
