### PR TITLE
feat(port): require every configured endpoint to become ready

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (2.23.0)
+    nonnative (3.0.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ High-level configuration fields:
 
 Common runner fields:
 - `name`: runner name used for lookup.
-- `host`/`port`: client-facing address. `host` defaults to `127.0.0.1`. For processes and servers, this address is also used for readiness/shutdown port checks. When a `fault_injection` proxy is enabled, this is the endpoint your tests/clients should hit.
+- `host`/`ports`: client-facing address. `host` defaults to `127.0.0.1`. For processes and servers, this address is also used for readiness/shutdown port checks. When a `fault_injection` proxy is enabled, clients should hit the first configured port.
 
 Process/server fields:
 - `timeout`: max time (seconds) for readiness/shutdown port checks.
@@ -68,9 +68,9 @@ Process/server fields:
 For `fault_injection`, the nested `proxy.host`/`proxy.port` describe the upstream target behind the proxy. Nested `proxy.host` also defaults to `127.0.0.1`. In-process server implementations typically bind there via `proxy.host` / `proxy.port`.
 
 > [!IMPORTANT]
-> When a proxy is enabled, tests and clients connect to the runner `host`/`port`; the nested `proxy.host`/`proxy.port` is the upstream target behind the proxy.
+> When a proxy is enabled, tests and clients connect to the runner `host` and first configured `ports` entry; the nested `proxy.host`/`proxy.port` is the upstream target behind the proxy.
 
-Nonnative readiness and shutdown checks are TCP-only. Configure ports that are dedicated to the test run; if another process is already listening on the same `host`/`port`, results are undefined.
+Nonnative readiness and shutdown checks are TCP-only. Configure ports that are dedicated to the test run; if another process is already listening on the same `host`/`ports` endpoint, results are undefined.
 
 > [!WARNING]
 > Readiness and shutdown checks only prove that a TCP port opened or closed. They do not verify HTTP status, gRPC health, schema readiness, migrations, or application-specific health.
@@ -168,7 +168,7 @@ Nonnative.configure do |config|
     p.command = -> { ['features/support/bin/start', '12_321'] }
     p.timeout = 5
     p.wait = 0.1
-    p.port = 12_321
+    p.ports = [12_321]
     p.log = '12_321.log'
     p.signal = 'INT' # Possible values are described in Signal.list.keys.
     p.environment = { # Pass environment variables to process.
@@ -181,7 +181,7 @@ Nonnative.configure do |config|
     p.command = -> { ['features/support/bin/start', '12_322'] }
     p.timeout = 0.5
     p.wait = 0.1
-    p.port = 12_322
+    p.ports = [12_322]
     p.log = '12_322.log'
   end
 end
@@ -202,7 +202,8 @@ processes:
       - "12_321"
     timeout: 5
     wait: 1
-    port: 12321
+    ports:
+      - 12321
     log: 12_321.log
     signal: INT # Possible values are described in Signal.list.keys.
     environment: # Pass environment variables to process.
@@ -214,7 +215,8 @@ processes:
       - "12_322"
     timeout: 5
     wait: 1
-    port: 12322
+    ports:
+      - 12322
     log: 12_322.log
 ```
 
@@ -285,7 +287,7 @@ Nonnative.configure do |config|
     s.name = 'server_1'
     s.klass = Nonnative::TCPServer
     s.timeout = 1
-    s.port = 12_323
+    s.ports = [12_323]
     s.log = 'server_1.log'
   end
 
@@ -293,7 +295,7 @@ Nonnative.configure do |config|
     s.name = 'server_2'
     s.klass = Nonnative::TCPServer
     s.timeout = 1
-    s.port = 12_324
+    s.ports = [12_324]
     s.log = 'server_2.log'
   end
 end
@@ -311,13 +313,15 @@ servers:
     name: server_1
     class: Nonnative::TCPServer
     timeout: 1
-    port: 12323
+    ports:
+      - 12323
     log: server_1.log
   -
     name: server_2
     class: Nonnative::TCPServer
     timeout: 1
-    port: 12324
+    ports:
+      - 12324
     log: server_2.log
 ```
 
@@ -368,7 +372,7 @@ Nonnative.configure do |config|
     s.name = 'http_server_1'
     s.klass = Nonnative::Features::HTTPServer
     s.timeout = 1
-    s.port = 4567
+    s.ports = [4567]
     s.log = 'http_server_1.log'
   end
 end
@@ -386,7 +390,8 @@ servers:
     name: http_server_1
     class: Nonnative::Features::HTTPServer
     timeout: 1
-    port: 4567
+    ports:
+      - 4567
     log: http_server_1.log
 ```
 
@@ -433,7 +438,7 @@ Nonnative.configure do |config|
     s.name = 'http_server_proxy'
     s.klass = Nonnative::Features::HTTPProxyServer
     s.timeout = 1
-    s.port = 4567
+    s.ports = [4567]
     s.log = 'http_server_proxy.log'
   end
 end
@@ -451,7 +456,8 @@ servers:
     name: http_server_proxy
     class: Nonnative::Features::HTTPProxyServer
     timeout: 1
-    port: 4567
+    ports:
+      - 4567
     log: http_server_proxy.log
 ```
 
@@ -502,7 +508,7 @@ Nonnative.configure do |config|
     s.name = 'grpc_server_1'
     s.klass = Nonnative::Features::GRPCServer
     s.timeout = 1
-    s.port = 9002
+    s.ports = [9002]
     s.log = 'grpc_server_1.log'
   end
 end
@@ -520,7 +526,8 @@ servers:
     name: grpc_server_1
     class: Nonnative::Features::GRPCServer
     timeout: 1
-    port: 9002
+    ports:
+      - 9002
     log: grpc_server_1.log
 ```
 
@@ -554,13 +561,13 @@ Nonnative.configure do |config|
   config.service do |s|
     s.name = 'postgres'
     s.host = '127.0.0.1'
-    s.port = 5432
+    s.ports = [5432]
   end
 
   config.service do |s|
     s.name = 'redis'
     s.host = '127.0.0.1'
-    s.port = 6379
+    s.ports = [6379]
   end
 end
 ```
@@ -576,11 +583,13 @@ services:
   -
     name: postgres
     host: 127.0.0.1
-    port: 5432
+    ports:
+      - 5432
   -
     name: redis
     host: 127.0.0.1
-    port: 6379
+    ports:
+      - 6379
 ```
 
 Then load the file with:
@@ -609,7 +618,7 @@ Custom proxy kinds can be registered through `Nonnative.proxies`:
 Nonnative.proxies['custom'] = CustomProxy
 ```
 
-For `fault_injection`, keep the runner `host`/`port` as the client-facing endpoint and use nested `proxy.host`/`proxy.port` for the upstream target behind the proxy.
+For `fault_injection`, keep the runner `host` and first `ports` entry as the client-facing endpoint and use nested `proxy.host`/`proxy.port` for the upstream target behind the proxy.
 
 ##### ⚙️ Process Proxies
 
@@ -626,7 +635,7 @@ Nonnative.configure do |config|
 
   config.process do |p|
     p.host = '127.0.0.1'
-    p.port = 20_000
+    p.ports = [20_000]
 
     p.proxy = {
       kind: 'fault_injection',
@@ -652,7 +661,8 @@ log: nonnative.log
 processes:
   -
     host: 127.0.0.1
-    port: 20000
+    ports:
+      - 20000
     proxy:
       kind: fault_injection
       host: 127.0.0.1
@@ -678,7 +688,7 @@ Nonnative.configure do |config|
 
   config.server do |s|
     s.host = '127.0.0.1'
-    s.port = 20_000
+    s.ports = [20_000]
 
     s.proxy = {
       kind: 'fault_injection',
@@ -704,7 +714,8 @@ log: nonnative.log
 servers:
   -
     host: 127.0.0.1
-    port: 20000
+    ports:
+      - 20000
     proxy:
       kind: fault_injection
       host: 127.0.0.1
@@ -731,7 +742,7 @@ Nonnative.configure do |config|
   config.service do |s|
     s.name = 'redis'
     s.host = '127.0.0.1'
-    s.port = 16_379
+    s.ports = [16_379]
 
     s.proxy = {
       kind: 'fault_injection',
@@ -758,7 +769,8 @@ services:
   -
     name: redis
     host: 127.0.0.1
-    port: 16379
+    ports:
+      - 16379
     proxy:
       kind: fault_injection
       host: 127.0.0.1
@@ -773,7 +785,7 @@ services:
 
 The `fault_injection` proxy allows you to simulate failures by injecting them. We currently support the following:
 
-Clients connect to the runner `host`/`port`, while the proxy forwards traffic to nested `proxy.host`/`proxy.port`.
+Clients connect to the runner `host` and first configured `ports` entry, while the proxy forwards traffic to nested `proxy.host`/`proxy.port`.
 
 - `close_all` - Closes the socket as soon as it connects.
 - `delay` - Delays traffic on the connection. Defaults to 2 seconds and can be configured through options.
@@ -847,7 +859,7 @@ Nonnative.configure do |config|
   config.process do |p|
     p.name = 'go'
     p.command = -> { Nonnative.go_argv(%w[cover], 'reports', 'your_binary', 'sub_command', '-i file:.config/server.yml') }
-    p.port = 12_345
+    p.ports = [12_345]
   end
 end
 ```
@@ -898,6 +910,7 @@ processes:
       parameters:
         - "-i file:.config/server.yml"
     timeout: 5
-    port: 8000
+    ports:
+      - 8000
     log: go.log
 ```

--- a/features/configs/go.yml
+++ b/features/configs/go.yml
@@ -12,5 +12,6 @@ processes:
       parameters:
         - --level=info
     timeout: 5
-    port: 8000
+    ports:
+      - 8000
     log: test/reports/go.log

--- a/features/configs/process_argv.yml
+++ b/features/configs/process_argv.yml
@@ -11,7 +11,8 @@ processes:
     timeout: 5
     wait: 0.2
     host: 127.0.0.1
-    port: 12402
+    ports:
+      - 12402
     log: test/reports/12_402.log
     signal: INT
     environment:

--- a/features/configs/processes.yml
+++ b/features/configs/processes.yml
@@ -8,15 +8,18 @@ processes:
     timeout: 5
     wait: 0.2
     host: 127.0.0.1
-    port: 12321
+    ports:
+      - 12321
     log: test/reports/12_321.log
     signal: INT
     environment:
       STRING: true
   - name: start_2
-    command: features/support/bin/start 12_322
+    command: features/support/bin/start 12_322,12_325
     timeout: 5
     wait: 0.2
-    port: 12322
+    ports:
+      - 12322
+      - 12325
     log: test/reports/12_322.log
     signal: TERM

--- a/features/configs/servers.yml
+++ b/features/configs/servers.yml
@@ -7,7 +7,8 @@ servers:
     class: Nonnative::Features::TCPServer
     timeout: 1
     host: 127.0.0.1
-    port: 12323
+    ports:
+      - 12323
     log: test/reports/tcp_server_1.log
     proxy:
       kind: fault_injection
@@ -17,7 +18,8 @@ servers:
   - name: tcp_server_2
     class: Nonnative::Features::TCPServer
     timeout: 1
-    port: 12324
+    ports:
+      - 12324
     log: test/reports/tcp_server_2.log
     proxy:
       kind: fault_injection
@@ -27,5 +29,6 @@ servers:
   - name: http_proxy_server
     class: Nonnative::Features::HTTPProxyServer
     timeout: 3
-    port: 4567
+    ports:
+      - 4567
     log: test/reports/http_proxy_server.log

--- a/features/configs/services.yml
+++ b/features/configs/services.yml
@@ -5,7 +5,8 @@ log: test/reports/nonnative.log
 services:
   - name: service_1
     host: 127.0.0.1
-    port: 20006
+    ports:
+      - 20006
     proxy:
       kind: fault_injection
       host: 127.0.0.1

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -8,8 +8,19 @@ Feature: Configuration loading
 
   Scenario: YAML keeps service and proxy endpoints separate
     Given I load a temporary configuration with split service and proxy endpoints
-    Then the configured service "service_1" should use host "127.0.0.1" and port 20006
+    Then the configured service "service_1" should use host "127.0.0.1" and ports:
+      | 20006 |
     And the configured service "service_1" proxy should use host "127.0.0.1" and port 30000
+
+  Scenario: YAML maps multiple runner ports
+    Given I load a temporary configuration with multiple runner ports
+    Then the configured process "multi_port_process" should use ports:
+      | 12420 |
+      | 12421 |
+
+  Scenario: YAML rejects singular runner ports
+    When I attempt to load a temporary configuration with a singular runner port
+    Then loading the configuration should fail with an argument error containing "Use 'ports' instead of 'port'"
 
   Scenario: YAML maps proxy options
     Given I load a temporary configuration with proxy options

--- a/features/lifecycle.feature
+++ b/features/lifecycle.feature
@@ -32,6 +32,12 @@ Feature: Lifecycle
       | Rollback failed for rollback_process with id |
       | because the process did not exit in time     |
 
+  Scenario: Process readiness requires every configured port to open
+    Given I configure the system with a process that opens only one configured port
+    When I attempt to start the system
+    Then starting the system should raise an error containing "Started partial_ports_process with id"
+    And starting the system should raise an error containing "though did not respond in time"
+
   Scenario: Pool starts services before servers and processes
     When I start a pool with ordered services, servers, and processes
     Then the lifecycle errors should be empty

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -9,7 +9,8 @@ Given('I load a temporary configuration with a service entry') do
     services:
       - name: service_1
         host: 127.0.0.1
-        port: 20006
+        ports:
+          - 20006
         proxy:
           kind: fault_injection
           host: 127.0.0.1
@@ -27,12 +28,31 @@ Given('I load a temporary configuration with split service and proxy endpoints')
     services:
       - name: service_1
         host: 127.0.0.1
-        port: 20006
+        ports:
+          - 20006
         proxy:
           kind: fault_injection
           host: 127.0.0.1
           port: 30000
           log: test/reports/proxy_service_1.log
+  YAML
+end
+
+Given('I load a temporary configuration with multiple runner ports') do
+  load_temporary_configuration(<<~YAML)
+    version: "1.0"
+    name: test
+    url: http://localhost:4567
+    log: test/reports/nonnative.log
+    processes:
+      - name: multi_port_process
+        command: features/support/bin/start 12_420,12_421
+        timeout: 1
+        host: 127.0.0.1
+        ports:
+          - 12420
+          - 12421
+        log: test/reports/12_420.log
   YAML
 end
 
@@ -45,7 +65,8 @@ Given('I load a temporary configuration with proxy options') do
     services:
       - name: service_1
         host: 127.0.0.1
-        port: 20006
+        ports:
+          - 20006
         proxy:
           kind: fault_injection
           host: 127.0.0.1
@@ -66,7 +87,8 @@ Given('I load a temporary configuration with a server entry') do
       - name: server_1
         class: Nonnative::Features::TCPServer
         timeout: 1
-        port: 12401
+        ports:
+          - 12401
         log: test/reports/server_1.log
   YAML
 end
@@ -83,7 +105,8 @@ Given('I load a temporary configuration with a top-level wait and a process') do
         command: features/support/bin/start 12_399
         timeout: 1
         host: 127.0.0.1
-        port: 12399
+        ports:
+          - 12399
         log: test/reports/12_399.log
   YAML
 end
@@ -108,7 +131,8 @@ Given('I load a temporary configuration with omitted hosts') do
       - name: default_host_process
         command: features/support/bin/start 12_400
         timeout: 1
-        port: 12400
+        ports:
+          - 12400
         log: test/reports/12_400.log
         proxy:
           kind: fault_injection
@@ -128,6 +152,24 @@ When('I attempt to load a temporary configuration with a Ruby object tag') do
   end
 end
 
+When('I attempt to load a temporary configuration with a singular runner port') do
+  @configuration_error = nil
+  capture_result(:@configuration_result, :@configuration_error) do
+    load_temporary_configuration(<<~YAML)
+      version: "1.0"
+      name: test
+      url: http://localhost:4567
+      log: test/reports/nonnative.log
+      processes:
+        - name: legacy_port_process
+          command: features/support/bin/start 12_400
+          timeout: 1
+          port: 12400
+          log: test/reports/12_400.log
+    YAML
+  end
+end
+
 When('I attempt to load a temporary configuration with {string} YAML') do |kind|
   @configuration_error = nil
   capture_result(:@configuration_result, :@configuration_error) do
@@ -140,11 +182,17 @@ Then('the configuration should contain {int} service entry and {int} process ent
   expect(Nonnative.configuration.processes.size).to eq(processes)
 end
 
-Then('the configured service {string} should use host {string} and port {int}') do |name, host, port|
+Then('the configured service {string} should use host {string} and ports:') do |name, host, table|
   service = configured_service(name)
 
   expect(service.host).to eq(host)
-  expect(service.port).to eq(port)
+  expect(service.ports).to eq(table.raw.flatten.map(&:to_i))
+end
+
+Then('the configured process {string} should use ports:') do |name, table|
+  process = configured_process(name)
+
+  expect(process.ports).to eq(table.raw.flatten.map(&:to_i))
 end
 
 Then('the configured service {string} proxy should use host {string} and port {int}') do |name, host, port|

--- a/features/step_definitions/lifecycle_steps.rb
+++ b/features/step_definitions/lifecycle_steps.rb
@@ -34,6 +34,21 @@ Given('I configure the system with a process that does not exit during rollback'
   end
 end
 
+Given('I configure the system with a process that opens only one configured port') do
+  configure_with_defaults do |config|
+    config.process do |process|
+      process.name = 'partial_ports_process'
+      process.command = -> { ['features/support/bin/start', '12415'] }
+      process.timeout = 1
+      process.wait = 0.1
+      process.host = '127.0.0.1'
+      process.ports = [12_415, 12_416]
+      process.log = 'test/reports/12_415.log'
+      process.signal = 'INT'
+    end
+  end
+end
+
 When('I start a pool with a failing unnamed service') do
   @lifecycle_errors = build_pool(
     services: [Nonnative::Features::FailingService.new(start_error: 'boom on service start')]

--- a/features/step_definitions/processes_steps.rb
+++ b/features/step_definitions/processes_steps.rb
@@ -29,7 +29,7 @@ Given('I configure the system programmatically with an argv process') do
       process.timeout = 5
       process.wait = 0.1
       process.host = '127.0.0.1'
-      process.port = 12_401
+      process.ports = [12_401]
       process.log = 'test/reports/12_401.log'
       process.signal = 'INT'
     end
@@ -47,7 +47,7 @@ Given('I configure the system programmatically with a shell string process') do
       process.timeout = 5
       process.wait = 0.1
       process.host = '127.0.0.1'
-      process.port = 12_413
+      process.ports = [12_413]
       process.log = 'test/reports/12_413.log'
       process.signal = 'INT'
     end
@@ -62,7 +62,7 @@ Given('I configure the system programmatically with a process that has no stop s
       process.timeout = 5
       process.wait = 0.1
       process.host = '127.0.0.1'
-      process.port = 12_414
+      process.ports = [12_414]
       process.log = 'test/reports/12_414.log'
     end
   end

--- a/features/support/bin/start
+++ b/features/support/bin/start
@@ -3,7 +3,7 @@
 
 require 'socket'
 
-port = ARGV.fetch(0).to_i
+ports = ARGV.fetch(0).split(',').map(&:to_i)
 options = ARGV.drop(1)
 environment_output = options.find { |option| option != 'linger' }
 linger = options.include?('linger')
@@ -23,13 +23,13 @@ end
 
 sleep 1 # Simulate delay
 
-server = TCPServer.new('0.0.0.0', port)
+servers = ports.map { |port| TCPServer.new('0.0.0.0', port) }
 
 $stdout.sync = true
 
 Thread.new do
   loop do
-    server.close if closing && !server.closed?
+    servers.each { |server| server.close if closing && !server.closed? }
     sleep 0.01
   rescue IOError
     nil
@@ -37,20 +37,26 @@ Thread.new do
 end
 
 begin
-  loop do
-    conn = server.accept
-    Thread.new(conn) do |socket|
+  servers.each do |server|
+    Thread.new(server) do |tcp_server|
       loop do
-        line = socket.readline.strip
-        puts "Received line: '#{line}'"
+        conn = tcp_server.accept
+        Thread.new(conn) do |socket|
+          loop do
+            line = socket.readline.strip
+            puts "Received line: '#{line}'"
 
-        socket.puts(line)
-        puts "Sent line: '#{line}'"
+            socket.puts(line)
+            puts "Sent line: '#{line}'"
+          end
+        rescue EOFError
+          socket.close
+        end
       end
-    rescue EOFError
-      socket.close
     end
   end
+
+  sleep
 rescue IOError, Errno::EBADF
   sleep if linger
 end

--- a/features/support/context/benchmark_configuration.rb
+++ b/features/support/context/benchmark_configuration.rb
@@ -6,13 +6,13 @@ module Nonnative
       module BenchmarkConfiguration
         def configure_no_op_server
           configure_with_defaults do |config|
-            add_server(config, klass: Nonnative::Features::NoOpServer, timeout: 1, port: 14_000)
+            add_server(config, klass: Nonnative::Features::NoOpServer, timeout: 1, ports: [14_000])
           end
         end
 
         def configure_no_stop_server
           configure_with_defaults do |config|
-            add_server(config, klass: Nonnative::Features::NoStopServer, timeout: 1, port: 14_001)
+            add_server(config, klass: Nonnative::Features::NoStopServer, timeout: 1, ports: [14_001])
           end
         end
 
@@ -24,7 +24,7 @@ module Nonnative
               host: '127.0.0.1',
               klass: Nonnative::Features::TCPServer,
               timeout: 1,
-              port: 14_002,
+              ports: [14_002],
               log: 'test/reports/14_002.log'
             )
             add_server(
@@ -33,7 +33,7 @@ module Nonnative
               host: '127.0.0.1',
               klass: Nonnative::Features::FailStartServer,
               timeout: 1,
-              port: 14_003,
+              ports: [14_003],
               log: 'test/reports/14_003.log'
             )
           end
@@ -48,7 +48,7 @@ module Nonnative
               timeout: 1,
               wait: 1,
               host: '127.0.0.1',
-              port: 14_006,
+              ports: [14_006],
               log: 'test/reports/14_006.log',
               signal: 'INT',
               proxy: {
@@ -70,7 +70,7 @@ module Nonnative
               host: '127.0.0.1',
               klass: Nonnative::Features::FailStopServer,
               timeout: 1,
-              port: 14_004,
+              ports: [14_004],
               log: 'test/reports/14_004.log'
             )
             add_server(
@@ -79,7 +79,7 @@ module Nonnative
               host: '127.0.0.1',
               klass: Nonnative::Features::TCPServer,
               timeout: 1,
-              port: 14_005,
+              ports: [14_005],
               log: 'test/reports/14_005.log'
             )
           end

--- a/features/support/context/http_proxy_configuration.rb
+++ b/features/support/context/http_proxy_configuration.rb
@@ -10,7 +10,7 @@ module Nonnative
             klass: 'Nonnative::Features::HTTPServer',
             timeout: 1,
             host: '127.0.0.1',
-            port: 4571,
+            ports: [4571],
             log: 'test/reports/http_proxy_target.log'
           },
           {
@@ -18,7 +18,7 @@ module Nonnative
             klass: 'Nonnative::Features::LocalHTTPProxyServer',
             timeout: 1,
             host: '127.0.0.1',
-            port: 4570,
+            ports: [4570],
             log: 'test/reports/local_http_proxy_server.log'
           }
         ].freeze
@@ -37,7 +37,7 @@ module Nonnative
             server.klass = Object.const_get(definition[:klass])
             server.timeout = definition[:timeout]
             server.host = definition[:host]
-            server.port = definition[:port]
+            server.ports = definition[:ports]
             server.log = definition[:log]
           end
         end

--- a/features/support/context/lifecycle_support.rb
+++ b/features/support/context/lifecycle_support.rb
@@ -15,7 +15,7 @@ module Nonnative
             process.timeout = 2
             process.wait = 0.1
             process.host = '127.0.0.1'
-            process.port = port
+            process.ports = [port]
             process.log = "test/reports/#{port}.log"
             process.signal = 'INT'
           end
@@ -28,7 +28,7 @@ module Nonnative
             process.timeout = 1
             process.wait = 0.1
             process.host = '127.0.0.1'
-            process.port = port
+            process.ports = [port]
             process.log = "test/reports/#{port}.log"
             process.signal = 'INT'
           end

--- a/features/support/context/process_configuration.rb
+++ b/features/support/context/process_configuration.rb
@@ -10,7 +10,7 @@ module Nonnative
             command: -> { 'features/support/bin/start 20_005' },
             timeout: 5,
             host: '127.0.0.1',
-            port: 12_321,
+            ports: [12_321],
             log: 'test/reports/12_321.log',
             signal: 'INT',
             environment: { 'STRING' => 'true' },
@@ -25,9 +25,9 @@ module Nonnative
           },
           {
             name: 'start_2',
-            command: -> { 'features/support/bin/start 12_322' },
+            command: -> { 'features/support/bin/start 12_322,12_325' },
             timeout: 5,
-            port: 12_322,
+            ports: [12_322, 12_325],
             log: 'test/reports/12_322.log',
             signal: 'TERM'
           }
@@ -48,7 +48,7 @@ module Nonnative
         end
 
         def apply_process_definition(process, definition)
-          %i[name command timeout wait host port log signal environment proxy].each do |attribute|
+          %i[name command timeout wait host ports log signal environment proxy].each do |attribute|
             assign_process_attribute(process, definition, attribute)
           end
         end

--- a/features/support/context/server_configuration.rb
+++ b/features/support/context/server_configuration.rb
@@ -9,14 +9,14 @@ module Nonnative
             name: 'tcp_server_1',
             klass: 'Nonnative::Features::TCPServer',
             timeout: 1,
-            port: 12_323,
+            ports: [12_323],
             log: 'test/reports/tcp_server_1.log'
           },
           {
             name: 'tcp_server_2',
             klass: 'Nonnative::Features::TCPServer',
             timeout: 1,
-            port: 12_324,
+            ports: [12_324],
             log: 'test/reports/tcp_server_2.log'
           },
           {
@@ -24,7 +24,7 @@ module Nonnative
             klass: 'Nonnative::Features::HTTPServer',
             timeout: 1,
             host: '127.0.0.1',
-            port: 4567,
+            ports: [4567],
             log: 'test/reports/http_server_1.log',
             proxy: {
               kind: 'fault_injection',
@@ -39,7 +39,7 @@ module Nonnative
             name: 'http_server_2',
             klass: 'Nonnative::Features::HTTPServer',
             timeout: 1,
-            port: 4568,
+            ports: [4568],
             log: 'test/reports/http_server_2.log',
             proxy: {
               kind: 'fault_injection',
@@ -53,7 +53,7 @@ module Nonnative
             name: 'grpc_server_1',
             klass: 'Nonnative::Features::GRPCServer',
             timeout: 1,
-            port: 9002,
+            ports: [9002],
             log: 'test/reports/grpc_server_1.log',
             proxy: {
               kind: 'fault_injection',
@@ -67,7 +67,7 @@ module Nonnative
             name: 'grpc_server_2',
             klass: 'Nonnative::Features::GRPCServer',
             timeout: 1,
-            port: 9003,
+            ports: [9003],
             log: 'test/reports/grpc_server_2.log',
             proxy: {
               kind: 'fault_injection',
@@ -96,7 +96,7 @@ module Nonnative
             server.klass = resolve_klass(definition[:klass])
             server.timeout = definition[:timeout]
             server.host = definition[:host] if definition[:host]
-            server.port = definition[:port]
+            server.ports = definition[:ports]
             server.log = definition[:log]
             server.proxy = definition[:proxy] if definition[:proxy]
           end

--- a/features/support/context/service_configuration.rb
+++ b/features/support/context/service_configuration.rb
@@ -8,7 +8,7 @@ module Nonnative
           {
             name: 'service_1',
             host: '127.0.0.1',
-            port: 20_006,
+            ports: [20_006],
             proxy: {
               kind: 'fault_injection',
               host: '127.0.0.1',
@@ -32,7 +32,7 @@ module Nonnative
           config.service do |service|
             service.name = definition[:name]
             service.host = definition[:host]
-            service.port = definition[:port]
+            service.ports = definition[:ports]
             service.proxy = definition[:proxy]
           end
         end

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -24,7 +24,7 @@
 #       p.name = 'api'
 #       p.command = -> { './bin/api' }
 #       p.host = '127.0.0.1'
-#       p.port = 8080
+#       p.ports = [8080, 9090]
 #       p.timeout = 10
 #       p.log = 'api.log'
 #     end
@@ -68,6 +68,7 @@ require 'nonnative/stop_error'
 require 'nonnative/not_found_error'
 require 'nonnative/timeout'
 require 'nonnative/port'
+require 'nonnative/ports'
 require 'nonnative/configuration_file'
 require 'nonnative/configuration'
 require 'nonnative/configuration_runner'
@@ -208,7 +209,7 @@ module Nonnative
 
     # Starts all configured services, servers, and processes, and waits for readiness.
     #
-    # Readiness is determined by attempting to connect to each runner's configured host/port.
+    # Readiness is determined by attempting to connect to each runner's configured host/ports.
     #
     # @return [void]
     # @raise [Nonnative::StartError] if one or more runners fail to start or become ready in time

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -19,7 +19,7 @@ module Nonnative
   #       p.name = 'api'
   #       p.command = -> { './bin/api' }
   #       p.host = '127.0.0.1'
-  #       p.port = 8080
+  #       p.ports = [8080, 9090]
   #       p.timeout = 10
   #       p.log = 'api.log'
   #     end
@@ -165,7 +165,7 @@ module Nonnative
         service do |service_config|
           service_config.name = loaded_service.name
           service_config.host = loaded_service.host if loaded_service.host
-          service_config.port = loaded_service.port
+          assign_ports(service_config, loaded_service)
 
           assign_proxy(service_config, loaded_service.proxy)
         end
@@ -182,8 +182,15 @@ module Nonnative
       runner.timeout = loaded.timeout
       runner.wait = loaded.wait if loaded.wait
       runner.host = loaded.host if loaded.host
-      runner.port = loaded.port
+      assign_ports(runner, loaded)
       runner.log = loaded.log if loaded.respond_to?(:log)
+    end
+
+    def assign_ports(runner, loaded)
+      values = loaded.to_h
+      raise ArgumentError, "Use 'ports' instead of 'port' for runner '#{loaded.name}'" if values.key?(:port) || values.key?('port')
+
+      runner.ports = loaded.ports if loaded.ports
     end
 
     def assign_proxy(runner, loaded_proxy)

--- a/lib/nonnative/configuration_process.rb
+++ b/lib/nonnative/configuration_process.rb
@@ -19,7 +19,7 @@ module Nonnative
     # @return [String, nil] signal name to use for stopping (defaults to `"INT"` when not set)
     attr_accessor :signal
 
-    # @return [Numeric] readiness timeout (seconds) used when waiting for the port to open/close
+    # @return [Numeric] readiness timeout (seconds) used when waiting for ports to open/close
     attr_accessor :timeout
 
     # @return [String] log file path to append process stdout/stderr to

--- a/lib/nonnative/configuration_runner.rb
+++ b/lib/nonnative/configuration_runner.rb
@@ -15,9 +15,12 @@ module Nonnative
   class ConfigurationRunner
     # @return [String, nil] runner name used for lookup (for example via `pool.process_by_name`)
     # @return [String] host to bind/connect to (defaults to `"127.0.0.1"`)
-    # @return [Integer] port to bind/connect to
+    # @return [Array<Integer>] ports to bind/connect to
     # @return [Numeric] wait interval (seconds) used by runners between lifecycle steps
-    attr_accessor :name, :host, :port, :wait
+    attr_accessor :name, :host, :wait
+
+    # @return [Array<Integer>] client-facing ports used for readiness/shutdown checks
+    attr_reader :ports
 
     # Proxy configuration for this runner.
     #
@@ -31,17 +34,35 @@ module Nonnative
     #
     # Defaults:
     # - `host`: `"127.0.0.1"`
-    # - `port`: `0`
+    # - `ports`: `[0]`
     # - `wait`: `0.1`
     # - `proxy`: a new {Nonnative::ConfigurationProxy} with its own defaults
     #
     # @return [void]
     def initialize
       self.host = '127.0.0.1'
-      self.port = 0
+      self.ports = [0]
       self.wait = 0.1
 
       @proxy = Nonnative::ConfigurationProxy.new
+    end
+
+    # Sets the client-facing ports for this runner.
+    #
+    # @param value [Array<Integer>] ports to check for readiness/shutdown
+    # @return [void]
+    def ports=(value)
+      @ports = Array(value)
+    end
+
+    # Returns the primary client-facing port.
+    #
+    # This preserves a single endpoint for proxy binding and client helpers while the public
+    # configuration contract uses {#ports}.
+    #
+    # @return [Integer]
+    def port
+      ports.first
     end
 
     # Sets proxy configuration using a hash-like value.

--- a/lib/nonnative/configuration_server.rb
+++ b/lib/nonnative/configuration_server.rb
@@ -12,7 +12,7 @@ module Nonnative
   # @see Nonnative::Server
   class ConfigurationServer < ConfigurationRunner
     # @return [Class] a class that implements `#initialize(service)`, and lifecycle hooks expected by {Nonnative::Server}
-    # @return [Numeric] readiness timeout (seconds) used when waiting for the port to open/close
+    # @return [Numeric] readiness timeout (seconds) used when waiting for ports to open/close
     # @return [String] log file path used by server implementations (for example Puma/gRPC log files)
     attr_accessor :klass, :timeout, :log
   end

--- a/lib/nonnative/fault_injection_proxy.rb
+++ b/lib/nonnative/fault_injection_proxy.rb
@@ -18,8 +18,8 @@ module Nonnative
   #
   # ## Wiring
   #
-  # When enabled, your test/client should connect to the runner `host` / `port` (the proxy endpoint),
-  # and the proxy will forward traffic to the upstream target exposed by {#host}:{#port}.
+  # When enabled, your test/client should connect to the runner `host` and first configured port (the
+  # proxy endpoint), and the proxy will forward traffic to the upstream target exposed by {#host}:{#port}.
   #
   # ## Configuration
   #
@@ -62,7 +62,7 @@ module Nonnative
 
     # Starts the proxy accept loop in a background thread.
     #
-    # This binds a TCP server on the underlying runner’s `service.host` / `service.port`.
+    # This binds a TCP server on the underlying runner’s `service.host` and first configured port.
     # Clients connect to that runner endpoint, while upstream traffic is forwarded to {#host}:{#port}.
     #
     # @return [void]

--- a/lib/nonnative/grpc_server.rb
+++ b/lib/nonnative/grpc_server.rb
@@ -34,7 +34,7 @@ module Nonnative
     # Binds the gRPC server and begins serving requests.
     #
     # The server binds to the upstream proxy host/port so the fault-injection proxy can expose the
-    # runner host/port as the client-facing endpoint used by readiness checks.
+    # runner host and first configured port as the client-facing endpoint used by readiness checks.
     #
     # @return [void]
     def perform_start

--- a/lib/nonnative/http_proxy_server.rb
+++ b/lib/nonnative/http_proxy_server.rb
@@ -110,7 +110,7 @@ module Nonnative
   #       s.klass = Nonnative::Features::HTTPProxyServer
   #       s.timeout = 2
   #       s.host = '127.0.0.1'
-  #       s.port = 4567
+  #       s.ports = [4567]
   #       s.log = 'proxy.log'
   #     end
   #   end

--- a/lib/nonnative/http_server.rb
+++ b/lib/nonnative/http_server.rb
@@ -20,7 +20,7 @@ module Nonnative
   #       s.klass = ->(service) { Nonnative::HTTPServer.new(app, service) }
   #       s.timeout = 2
   #       s.host = '127.0.0.1'
-  #       s.port = 4567
+  #       s.ports = [4567]
   #       s.log = 'http.log'
   #     end
   #   end
@@ -49,7 +49,7 @@ module Nonnative
     # Binds the Puma server and begins serving.
     #
     # The listener binds to the upstream proxy host/port so the fault-injection proxy can expose the
-    # runner host/port as the client-facing endpoint used by readiness checks.
+    # runner host and first configured port as the client-facing endpoint used by readiness checks.
     #
     # @return [void]
     def perform_start

--- a/lib/nonnative/no_proxy.rb
+++ b/lib/nonnative/no_proxy.rb
@@ -5,7 +5,7 @@ module Nonnative
   #
   # This is the default proxy when `service.proxy.kind` is `"none"` (or an unknown kind is provided).
   # It does not bind/listen or alter traffic; it simply exposes the underlying runner's configured
-  # `host` and `port`.
+  # `host` and primary `port`.
   #
   # Runners can always call `start`, `stop`, and `reset` safely on this proxy.
   #
@@ -50,7 +50,7 @@ module Nonnative
 
     # Returns the port clients should connect to.
     #
-    # For {NoProxy}, this is the underlying runner configuration port.
+    # For {NoProxy}, this is the first underlying runner configuration port.
     #
     # @return [Integer]
     def port

--- a/lib/nonnative/pool.rb
+++ b/lib/nonnative/pool.rb
@@ -9,7 +9,7 @@ module Nonnative
   # - On start: services first, then servers/processes (in parallel port-check threads)
   # - On stop: processes/servers first, then services
   #
-  # Readiness and shutdown are determined via TCP port checks ({Nonnative::Port#open?} / {Nonnative::Port#closed?}).
+  # Readiness and shutdown are determined via TCP port checks ({Nonnative::Ports#open?} / {Nonnative::Ports#closed?}).
   #
   # @see Nonnative.start
   # @see Nonnative.stop
@@ -131,7 +131,7 @@ module Nonnative
 
       @processes = []
       configuration.processes.each do |p|
-        @processes << [Nonnative::Process.new(p), Nonnative::Port.new(p)]
+        @processes << [Nonnative::Process.new(p), Nonnative::Ports.new(p)]
       end
 
       @processes
@@ -142,7 +142,7 @@ module Nonnative
 
       @servers = []
       configuration.servers.each do |s|
-        @servers << [s.klass.new(s), Nonnative::Port.new(s)]
+        @servers << [s.klass.new(s), Nonnative::Ports.new(s)]
       end
 
       @servers

--- a/lib/nonnative/port.rb
+++ b/lib/nonnative/port.rb
@@ -3,21 +3,23 @@
 module Nonnative
   # Performs TCP port readiness/shutdown checks for a configured runner.
   #
-  # Nonnative uses this to decide whether a process/server is ready after start, and whether it has
-  # shut down after stop. The checks repeatedly attempt to open a TCP connection to `process.host`
-  # and `process.port` until either:
+  # Nonnative uses this to decide whether a process/server port is ready after start, and whether it
+  # has shut down after stop. The checks repeatedly attempt to open a TCP connection to `process.host`
+  # and the configured `port` until either:
   #
   # - the expected condition is met, or
   # - the configured timeout elapses (in which case the method returns `false`)
   #
   # The `process` argument is a runner configuration object (e.g. {Nonnative::ConfigurationProcess}
-  # or {Nonnative::ConfigurationServer}) that responds to `host`, `port`, and `timeout`.
+  # or {Nonnative::ConfigurationServer}) that responds to `host` and `timeout`.
   #
   # @see Nonnative::Pool for how these checks are orchestrated during start/stop
   class Port
-    # @param process [#host, #port, #timeout] runner configuration providing connection details
-    def initialize(process)
+    # @param process [#host, #timeout] runner configuration providing connection details
+    # @param port [Integer] port to check
+    def initialize(process, port = process.port)
       @process = process
+      @port = port
       @timeout = Nonnative::Timeout.new(process.timeout)
     end
 
@@ -28,7 +30,7 @@ module Nonnative
     #
     # @return [Boolean] `true` if the port opened in time; otherwise `false`
     def open?
-      Nonnative.logger.info "checking if port '#{process.port}' is open on host '#{process.host}'"
+      Nonnative.logger.info "checking if port '#{port}' is open on host '#{process.host}'"
 
       timeout.perform do
         open_socket
@@ -46,7 +48,7 @@ module Nonnative
     #
     # @return [Boolean] `true` if the port closed in time; otherwise `false`
     def closed?
-      Nonnative.logger.info "checking if port '#{process.port}' is closed on host '#{process.host}'"
+      Nonnative.logger.info "checking if port '#{port}' is closed on host '#{process.host}'"
 
       timeout.perform do
         open_socket
@@ -61,10 +63,10 @@ module Nonnative
 
     private
 
-    attr_reader :process, :timeout
+    attr_reader :process, :port, :timeout
 
     def open_socket
-      TCPSocket.new(process.host, process.port).close
+      TCPSocket.new(process.host, port).close
     end
 
     def sleep_interval

--- a/lib/nonnative/ports.rb
+++ b/lib/nonnative/ports.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Nonnative
+  # Performs aggregate TCP readiness/shutdown checks for all configured runner ports.
+  #
+  # A runner is considered ready only when every configured port is open, and stopped only when every
+  # configured port is closed.
+  #
+  # @see Nonnative::Port
+  class Ports
+    # @param runner [#host, #ports, #timeout] runner configuration providing connection details
+    def initialize(runner)
+      @ports = runner.ports.map { |port| Nonnative::Port.new(runner, port) }
+    end
+
+    # Returns whether all configured ports become connectable before their timeouts elapse.
+    #
+    # @return [Boolean]
+    def open?
+      ports.all?(&:open?)
+    end
+
+    # Returns whether all configured ports become non-connectable before their timeouts elapse.
+    #
+    # @return [Boolean]
+    def closed?
+      ports.all?(&:closed?)
+    end
+
+    private
+
+    attr_reader :ports
+  end
+end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '2.23.0'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
## What

- Replace runner `port` configuration with `ports` for processes, servers, and services.
- Require every configured process/server endpoint to open before startup is considered ready, and to close before shutdown is considered complete.
- Reject YAML runner entries that still use singular `port`, while keeping nested `proxy.port` as the upstream proxy target.
- Update fixtures, examples, README docs, and the gem version for the 3.0.0 breaking release.

## Why

- Some systems expose multiple TCP endpoints during one runner lifecycle, and a single endpoint check can mark them ready before all required listeners are available.
- Failing old YAML with a direct migration message avoids silently defaulting to an unusable endpoint after the breaking config shape change.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- `git diff --check` - passed

BREAKING CHANGE: Runner configuration now uses `ports` instead of `port` so every configured endpoint is checked before a process or server is considered ready or stopped.
