### PR TITLE
feat(port): require every configured endpoint to become ready

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.0.0)
+    nonnative (3.1.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -58,19 +58,23 @@ High-level configuration fields:
 
 Common runner fields:
 - `name`: runner name used for lookup.
-- `host`/`ports`: client-facing address. `host` defaults to `127.0.0.1`. For processes and servers, this address is also used for readiness/shutdown port checks. When a `fault_injection` proxy is enabled, clients should hit the first configured port.
+- `host`: client-facing host. Defaults to `127.0.0.1`.
 
 Process/server fields:
+- `ports`: client-facing ports. These are also used for readiness/shutdown port checks. When a `fault_injection` proxy is enabled, clients should hit the first configured port.
 - `timeout`: max time (seconds) for readiness/shutdown port checks.
 - `wait`: small sleep (seconds) between lifecycle steps.
 - `log`: per-runner log file used by process output redirection or server implementations.
 
+Service fields:
+- `port`: client-facing proxy port. Services do not get TCP readiness/shutdown checks from Nonnative.
+
 For `fault_injection`, the nested `proxy.host`/`proxy.port` describe the upstream target behind the proxy. Nested `proxy.host` also defaults to `127.0.0.1`. In-process server implementations typically bind there via `proxy.host` / `proxy.port`.
 
 > [!IMPORTANT]
-> When a proxy is enabled, tests and clients connect to the runner `host` and first configured `ports` entry; the nested `proxy.host`/`proxy.port` is the upstream target behind the proxy.
+> When a proxy is enabled, tests and clients connect to the runner `host` and client-facing endpoint (`ports` first entry for processes/servers, `port` for services); the nested `proxy.host`/`proxy.port` is the upstream target behind the proxy.
 
-Nonnative readiness and shutdown checks are TCP-only. Configure ports that are dedicated to the test run; if another process is already listening on the same `host`/`ports` endpoint, results are undefined.
+Nonnative readiness and shutdown checks are TCP-only. Configure process/server ports that are dedicated to the test run; if another process is already listening on the same endpoint, results are undefined.
 
 > [!WARNING]
 > Readiness and shutdown checks only prove that a TCP port opened or closed. They do not verify HTTP status, gRPC health, schema readiness, migrations, or application-specific health.
@@ -561,13 +565,13 @@ Nonnative.configure do |config|
   config.service do |s|
     s.name = 'postgres'
     s.host = '127.0.0.1'
-    s.ports = [5432]
+    s.port = 5432
   end
 
   config.service do |s|
     s.name = 'redis'
     s.host = '127.0.0.1'
-    s.ports = [6379]
+    s.port = 6379
   end
 end
 ```
@@ -583,13 +587,11 @@ services:
   -
     name: postgres
     host: 127.0.0.1
-    ports:
-      - 5432
+    port: 5432
   -
     name: redis
     host: 127.0.0.1
-    ports:
-      - 6379
+    port: 6379
 ```
 
 Then load the file with:
@@ -742,7 +744,7 @@ Nonnative.configure do |config|
   config.service do |s|
     s.name = 'redis'
     s.host = '127.0.0.1'
-    s.ports = [16_379]
+    s.port = 16_379
 
     s.proxy = {
       kind: 'fault_injection',
@@ -769,8 +771,7 @@ services:
   -
     name: redis
     host: 127.0.0.1
-    ports:
-      - 16379
+    port: 16379
     proxy:
       kind: fault_injection
       host: 127.0.0.1
@@ -785,7 +786,7 @@ services:
 
 The `fault_injection` proxy allows you to simulate failures by injecting them. We currently support the following:
 
-Clients connect to the runner `host` and first configured `ports` entry, while the proxy forwards traffic to nested `proxy.host`/`proxy.port`.
+Clients connect to the runner `host` and client-facing endpoint, while the proxy forwards traffic to nested `proxy.host`/`proxy.port`.
 
 - `close_all` - Closes the socket as soon as it connects.
 - `delay` - Delays traffic on the connection. Defaults to 2 seconds and can be configured through options.

--- a/features/configs/services.yml
+++ b/features/configs/services.yml
@@ -5,8 +5,7 @@ log: test/reports/nonnative.log
 services:
   - name: service_1
     host: 127.0.0.1
-    ports:
-      - 20006
+    port: 20006
     proxy:
       kind: fault_injection
       host: 127.0.0.1

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -8,8 +8,7 @@ Feature: Configuration loading
 
   Scenario: YAML keeps service and proxy endpoints separate
     Given I load a temporary configuration with split service and proxy endpoints
-    Then the configured service "service_1" should use host "127.0.0.1" and ports:
-      | 20006 |
+    Then the configured service "service_1" should use host "127.0.0.1" and port 20006
     And the configured service "service_1" proxy should use host "127.0.0.1" and port 30000
 
   Scenario: YAML maps multiple runner ports
@@ -18,9 +17,17 @@ Feature: Configuration loading
       | 12420 |
       | 12421 |
 
-  Scenario: YAML rejects singular runner ports
+  Scenario: YAML rejects singular process ports
     When I attempt to load a temporary configuration with a singular runner port
     Then loading the configuration should fail with an argument error containing "Use 'ports' instead of 'port'"
+
+  Scenario: YAML rejects plural service ports
+    When I attempt to load a temporary configuration with plural service ports
+    Then loading the configuration should fail with an argument error containing "Use 'port' instead of 'ports'"
+
+  Scenario: Programmatic configuration rejects plural service ports
+    When I attempt to configure a service with plural ports
+    Then loading the configuration should fail with an argument error containing "Use 'port' instead of 'ports'"
 
   Scenario: YAML maps proxy options
     Given I load a temporary configuration with proxy options

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -9,8 +9,7 @@ Given('I load a temporary configuration with a service entry') do
     services:
       - name: service_1
         host: 127.0.0.1
-        ports:
-          - 20006
+        port: 20006
         proxy:
           kind: fault_injection
           host: 127.0.0.1
@@ -28,8 +27,7 @@ Given('I load a temporary configuration with split service and proxy endpoints')
     services:
       - name: service_1
         host: 127.0.0.1
-        ports:
-          - 20006
+        port: 20006
         proxy:
           kind: fault_injection
           host: 127.0.0.1
@@ -65,8 +63,7 @@ Given('I load a temporary configuration with proxy options') do
     services:
       - name: service_1
         host: 127.0.0.1
-        ports:
-          - 20006
+        port: 20006
         proxy:
           kind: fault_injection
           host: 127.0.0.1
@@ -170,6 +167,40 @@ When('I attempt to load a temporary configuration with a singular runner port') 
   end
 end
 
+When('I attempt to load a temporary configuration with plural service ports') do
+  @configuration_error = nil
+  capture_result(:@configuration_result, :@configuration_error) do
+    load_temporary_configuration(<<~YAML)
+      version: "1.0"
+      name: test
+      url: http://localhost:4567
+      log: test/reports/nonnative.log
+      services:
+        - name: legacy_ports_service
+          host: 127.0.0.1
+          ports:
+            - 12400
+          proxy:
+            kind: fault_injection
+            host: 127.0.0.1
+            port: 30000
+            log: test/reports/proxy_legacy_ports_service.log
+    YAML
+  end
+end
+
+When('I attempt to configure a service with plural ports') do
+  @configuration_error = nil
+  capture_result(:@configuration_result, :@configuration_error) do
+    Nonnative.configure do |config|
+      config.service do |service|
+        service.name = 'legacy_ports_service'
+        service.ports = [12_400]
+      end
+    end
+  end
+end
+
 When('I attempt to load a temporary configuration with {string} YAML') do |kind|
   @configuration_error = nil
   capture_result(:@configuration_result, :@configuration_error) do
@@ -182,11 +213,11 @@ Then('the configuration should contain {int} service entry and {int} process ent
   expect(Nonnative.configuration.processes.size).to eq(processes)
 end
 
-Then('the configured service {string} should use host {string} and ports:') do |name, host, table|
+Then('the configured service {string} should use host {string} and port {int}') do |name, host, port|
   service = configured_service(name)
 
   expect(service.host).to eq(host)
-  expect(service.ports).to eq(table.raw.flatten.map(&:to_i))
+  expect(service.port).to eq(port)
 end
 
 Then('the configured process {string} should use ports:') do |name, table|

--- a/features/support/context/service_configuration.rb
+++ b/features/support/context/service_configuration.rb
@@ -8,7 +8,7 @@ module Nonnative
           {
             name: 'service_1',
             host: '127.0.0.1',
-            ports: [20_006],
+            port: 20_006,
             proxy: {
               kind: 'fault_injection',
               host: '127.0.0.1',
@@ -32,7 +32,7 @@ module Nonnative
           config.service do |service|
             service.name = definition[:name]
             service.host = definition[:host]
-            service.ports = definition[:ports]
+            service.port = definition[:port]
             service.proxy = definition[:proxy]
           end
         end

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -165,7 +165,7 @@ module Nonnative
         service do |service_config|
           service_config.name = loaded_service.name
           service_config.host = loaded_service.host if loaded_service.host
-          assign_ports(service_config, loaded_service)
+          assign_service_port(service_config, loaded_service)
 
           assign_proxy(service_config, loaded_service.proxy)
         end
@@ -191,6 +191,13 @@ module Nonnative
       raise ArgumentError, "Use 'ports' instead of 'port' for runner '#{loaded.name}'" if values.key?(:port) || values.key?('port')
 
       runner.ports = loaded.ports if loaded.ports
+    end
+
+    def assign_service_port(service, loaded)
+      values = loaded.to_h
+      raise ArgumentError, "Use 'port' instead of 'ports' for service '#{loaded.name}'" if values.key?(:ports) || values.key?('ports')
+
+      service.port = loaded.port if loaded.port
     end
 
     def assign_proxy(runner, loaded_proxy)

--- a/lib/nonnative/configuration_runner.rb
+++ b/lib/nonnative/configuration_runner.rb
@@ -41,7 +41,7 @@ module Nonnative
     # @return [void]
     def initialize
       self.host = '127.0.0.1'
-      self.ports = [0]
+      @ports = [0]
       self.wait = 0.1
 
       @proxy = Nonnative::ConfigurationProxy.new

--- a/lib/nonnative/configuration_service.rb
+++ b/lib/nonnative/configuration_service.rb
@@ -11,5 +11,33 @@ module Nonnative
   # @see Nonnative::Configuration
   # @see Nonnative::Service
   class ConfigurationService < ConfigurationRunner
+    # @return [Integer] client-facing port used by the service proxy
+    attr_accessor :port
+
+    # Creates a service configuration with defaults.
+    #
+    # @return [void]
+    def initialize
+      super
+
+      self.port = 0
+    end
+
+    # Services expose a single proxy listener, so plural runner ports are not supported.
+    #
+    # @return [void]
+    # @raise [ArgumentError] when plural service ports are read
+    def ports
+      raise ArgumentError, "Use 'port' instead of 'ports' for service '#{name}'"
+    end
+
+    # Services expose a single proxy listener, so plural runner ports are not supported.
+    #
+    # @param _value [Array<Integer>] ignored plural ports
+    # @return [void]
+    # @raise [ArgumentError] when plural service ports are assigned
+    def ports=(_value)
+      raise ArgumentError, "Use 'port' instead of 'ports' for service '#{name}'"
+    end
   end
 end

--- a/lib/nonnative/fault_injection_proxy.rb
+++ b/lib/nonnative/fault_injection_proxy.rb
@@ -18,8 +18,8 @@ module Nonnative
   #
   # ## Wiring
   #
-  # When enabled, your test/client should connect to the runner `host` and first configured port (the
-  # proxy endpoint), and the proxy will forward traffic to the upstream target exposed by {#host}:{#port}.
+  # When enabled, your test/client should connect to the runner `host` and primary port (the proxy
+  # endpoint), and the proxy will forward traffic to the upstream target exposed by {#host}:{#port}.
   #
   # ## Configuration
   #
@@ -62,7 +62,7 @@ module Nonnative
 
     # Starts the proxy accept loop in a background thread.
     #
-    # This binds a TCP server on the underlying runner’s `service.host` and first configured port.
+    # This binds a TCP server on the underlying runner’s `service.host` and primary port.
     # Clients connect to that runner endpoint, while upstream traffic is forwarded to {#host}:{#port}.
     #
     # @return [void]

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.0.0'
+  VERSION = '3.1.0'
 end


### PR DESCRIPTION
## What

- Add aggregate process/server TCP checks so every configured endpoint must open before startup and close before shutdown.
- Keep service configuration on singular `port`, because services are proxy-only and bind one client-facing proxy listener.
- Reject old process/server `port` YAML with a `ports` migration message and reject service `ports` usage in YAML or programmatic configuration with a `port` migration message.
- Update fixtures, docs, and version metadata for the 3.1.0 release.

## Why

- Some managed runners expose multiple TCP endpoints, and checking only one can mark them ready too early.
- Service proxy configuration still represents a single listener, so keeping `port` avoids forcing a plural shape where Nonnative cannot start multiple proxies.

## Testing

- `make lint` - passed
- `make features feature=features/configuration.feature` - passed
- `make features` - passed
- `make benchmarks` - passed
- `git diff --check` - passed
