### PR TITLE
feat(proxy): limit fault injection to services

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.1.0)
+    nonnative (3.2.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Nonnative is a Ruby-first harness for end-to-end testing of systems implemented 
 It helps you:
 - start **OS processes** (e.g. your Go/Java/Rust service binary),
 - start **in-process Ruby servers** (e.g. small HTTP/TCP/gRPC fakes for dependencies),
-- optionally start **proxies** in front of processes/servers/services for fault-injection,
+- optionally start **service proxies** for fault-injection in front of externally managed dependencies,
 - wait for readiness/shutdown using **TCP port checks**.
 
 Once started, you can test however you like (TCP, HTTP, gRPC, etc).
@@ -54,25 +54,20 @@ High-level configuration fields:
 - `log`: path for the Nonnative logger output.
 - `processes`: child processes to `spawn`.
 - `servers`: in-process Ruby servers started in threads.
-- `services`: external dependencies (proxy-only; no process/thread started by Nonnative).
+- `services`: external dependencies (no process/thread started by Nonnative).
 
 Common runner fields:
 - `name`: runner name used for lookup.
 - `host`: client-facing host. Defaults to `127.0.0.1`.
 
 Process/server fields:
-- `ports`: client-facing ports. These are also used for readiness/shutdown port checks. When a `fault_injection` proxy is enabled, clients should hit the first configured port.
+- `ports`: client-facing ports. These are also used for readiness/shutdown port checks.
 - `timeout`: max time (seconds) for readiness/shutdown port checks.
 - `wait`: small sleep (seconds) between lifecycle steps.
 - `log`: per-runner log file used by process output redirection or server implementations.
 
 Service fields:
-- `port`: client-facing proxy port. Services do not get TCP readiness/shutdown checks from Nonnative.
-
-For `fault_injection`, the nested `proxy.host`/`proxy.port` describe the upstream target behind the proxy. Nested `proxy.host` also defaults to `127.0.0.1`. In-process server implementations typically bind there via `proxy.host` / `proxy.port`.
-
-> [!IMPORTANT]
-> When a proxy is enabled, tests and clients connect to the runner `host` and client-facing endpoint (`ports` first entry for processes/servers, `port` for services); the nested `proxy.host`/`proxy.port` is the upstream target behind the proxy.
+- `port`: client-facing service port. Services do not get TCP readiness/shutdown checks from Nonnative.
 
 Nonnative readiness and shutdown checks are TCP-only. Configure process/server ports that are dedicated to the test run; if another process is already listening on the same endpoint, results are undefined.
 
@@ -252,7 +247,7 @@ module Nonnative
     def initialize(service)
       super
 
-      @socket_server = ::TCPServer.new(proxy.host, proxy.port)
+      @socket_server = ::TCPServer.new(service.host, service.port)
     end
 
     def perform_start
@@ -409,9 +404,9 @@ Nonnative.configure do |config|
 end
 ```
 
-##### 🔀 Proxy
+##### 🔀 HTTP Forward Proxy
 
-The system allows you to define an HTTP proxy for external systems, e.g. `api.github.com`.
+The system allows you to define an in-process HTTP forward proxy server for external systems, e.g. `api.github.com`. This is a server implementation, not a fault-injection service proxy.
 
 Define your server:
 
@@ -547,9 +542,9 @@ end
 
 ### 🧩 Services
 
-A service is an external dependency to your system that you **do not** want Nonnative to start (no OS process, no Ruby thread). Services are primarily useful when paired with proxies, because they let you inject failures into dependencies that are managed elsewhere (e.g. a DB running in Docker).
+A service is an external dependency to your system that you **do not** want Nonnative to start (no OS process, no Ruby thread).
 
-Services do not get process lifecycle management or TCP readiness/shutdown checks from Nonnative. They only provide a named runner and optional proxy lifecycle for a dependency that another tool already manages.
+Services do not get process lifecycle management or TCP readiness/shutdown checks from Nonnative. They provide a named endpoint for a dependency that another tool already manages.
 
 Set it up programmatically:
 
@@ -620,153 +615,38 @@ Custom proxy kinds can be registered through `Nonnative.proxies`:
 Nonnative.proxies['custom'] = CustomProxy
 ```
 
-For `fault_injection`, keep the runner `host` and first `ports` entry as the client-facing endpoint and use nested `proxy.host`/`proxy.port` for the upstream target behind the proxy.
-
-##### ⚙️ Process Proxies
-
-Add this to an existing process configuration:
-
-```ruby
-require 'nonnative'
-
-Nonnative.configure do |config|
-  config.version = '1.0'
-  config.name = 'test'
-  config.url = 'http://localhost:4567'
-  config.log = 'nonnative.log'
-
-  config.process do |p|
-    p.host = '127.0.0.1'
-    p.ports = [20_000]
-
-    p.proxy = {
-      kind: 'fault_injection',
-      host: '127.0.0.1',
-      port: 12_321,
-      log: 'proxy_server.log',
-      wait: 1,
-      options: {
-        delay: 5
-      }
-    }
-  end
-end
-```
-
-YAML fragment:
-
-```yaml
-version: "1.0"
-name: test
-url: http://localhost:4567
-log: nonnative.log
-processes:
-  -
-    host: 127.0.0.1
-    ports:
-      - 20000
-    proxy:
-      kind: fault_injection
-      host: 127.0.0.1
-      port: 12321
-      log: proxy_server.log
-      wait: 1
-      options:
-        delay: 5
-```
-
-##### 🖥️ Server Proxies
-
-Add this to an existing server configuration:
-
-```ruby
-require 'nonnative'
-
-Nonnative.configure do |config|
-  config.version = '1.0'
-  config.name = 'test'
-  config.url = 'http://localhost:4567'
-  config.log = 'nonnative.log'
-
-  config.server do |s|
-    s.host = '127.0.0.1'
-    s.ports = [20_000]
-
-    s.proxy = {
-      kind: 'fault_injection',
-      host: '127.0.0.1',
-      port: 12_321,
-      log: 'proxy_server.log',
-      wait: 1,
-      options: {
-        delay: 5
-      }
-    }
-  end
-end
-```
-
-YAML fragment:
-
-```yaml
-version: "1.0"
-name: test
-url: http://localhost:4567
-log: nonnative.log
-servers:
-  -
-    host: 127.0.0.1
-    ports:
-      - 20000
-    proxy:
-      kind: fault_injection
-      host: 127.0.0.1
-      port: 12321
-      log: proxy_server.log
-      wait: 1
-      options:
-        delay: 5
-```
+Only services support proxies. For `fault_injection`, keep the service `host`/`port` as the client-facing proxy endpoint and use nested `proxy.host`/`proxy.port` for the upstream target behind the proxy.
 
 ##### 🧩 Service Proxies
 
-Add this to an existing service configuration:
+###### Programmatic Configuration
+
+Add a proxy to a service configuration:
 
 ```ruby
-require 'nonnative'
+config.service do |s|
+  s.name = 'redis'
+  s.host = '127.0.0.1'
+  s.port = 16_379
 
-Nonnative.configure do |config|
-  config.version = '1.0'
-  config.name = 'test'
-  config.url = 'http://localhost:4567'
-  config.log = 'nonnative.log'
-
-  config.service do |s|
-    s.name = 'redis'
-    s.host = '127.0.0.1'
-    s.port = 16_379
-
-    s.proxy = {
-      kind: 'fault_injection',
-      host: '127.0.0.1',
-      port: 6379,
-      log: 'proxy_server.log',
-      wait: 1,
-      options: {
-        delay: 5
-      }
+  s.proxy = {
+    kind: 'fault_injection',
+    host: '127.0.0.1',
+    port: 6379,
+    log: 'proxy_server.log',
+    wait: 1,
+    options: {
+      delay: 5
     }
-  end
+  }
 end
 ```
 
-YAML fragment:
+###### YAML Configuration
+
+Add a proxy to a service YAML entry:
 
 ```yaml
-version: "1.0"
-name: test
-url: http://localhost:4567
-log: nonnative.log
 services:
   -
     name: redis
@@ -786,53 +666,15 @@ services:
 
 The `fault_injection` proxy allows you to simulate failures by injecting them. We currently support the following:
 
-Clients connect to the runner `host` and client-facing endpoint, while the proxy forwards traffic to nested `proxy.host`/`proxy.port`.
+Clients connect to the service `host`/`port`, while the proxy forwards traffic to nested `proxy.host`/`proxy.port`.
 
 - `close_all` - Closes the socket as soon as it connects.
 - `delay` - Delays traffic on the connection. Defaults to 2 seconds and can be configured through options.
 - `invalid_data` - Forwards client requests unchanged, then corrupts upstream responses before they reach the client.
 
-###### ⚙️ Fault Injection Processes
-
-Set it up programmatically:
-
-```ruby
-name = 'name of process in configuration'
-server = Nonnative.pool.process_by_name(name)
-
-server.proxy.close_all # To use close_all.
-server.proxy.reset # To reset it back to a good state.
-```
-
-With cucumber:
-
-```cucumber
-Given I set the proxy for process 'process_1' to 'close_all'
-Then I should reset the proxy for process 'process_1'
-```
-
-###### 🖥️ Fault Injection Servers
-
-Set it up programmatically:
-
-```ruby
-name = 'name of server in configuration'
-server = Nonnative.pool.server_by_name(name)
-
-server.proxy.close_all # To use close_all.
-server.proxy.reset # To reset it back to a good state.
-```
-
-With cucumber:
-
-```cucumber
-Given I set the proxy for server 'server_1' to 'close_all'
-Then I should reset the proxy for server 'server_1'
-```
-
 ###### 🧩 Fault Injection Services
 
-Set it up programmatically:
+Set the proxy state programmatically:
 
 ```ruby
 name = 'name of service in configuration'
@@ -842,7 +684,7 @@ service.proxy.close_all # To use close_all.
 service.proxy.reset # To reset it back to a good state.
 ```
 
-With cucumber:
+Use the Cucumber proxy steps:
 
 ```cucumber
 Given I set the proxy for service 'service_1' to 'close_all'

--- a/features/benchmark.feature
+++ b/features/benchmark.feature
@@ -29,7 +29,7 @@ Feature: Benchmark
     And the port '14002' should be closed
 
   @manual
-  Scenario: Start nonnative with a fast exiting process will rollback its proxy
+  Scenario: Start nonnative with a fast exiting process will rollback the process
     Given I configure the system programmatically with a fast exiting process
     When I attempt to start the system
     Then starting the system should raise an error

--- a/features/configs/servers.yml
+++ b/features/configs/servers.yml
@@ -10,22 +10,12 @@ servers:
     ports:
       - 12323
     log: test/reports/tcp_server_1.log
-    proxy:
-      kind: fault_injection
-      host: 127.0.0.1
-      port: 20000
-      log: test/reports/proxy_tcp_server_1.log
   - name: tcp_server_2
     class: Nonnative::Features::TCPServer
     timeout: 1
     ports:
       - 12324
     log: test/reports/tcp_server_2.log
-    proxy:
-      kind: fault_injection
-      port: 20001
-      log: test/reports/proxy_tcp_server_2.log
-      wait: 1
   - name: http_proxy_server
     class: Nonnative::Features::HTTPProxyServer
     timeout: 3

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -29,9 +29,21 @@ Feature: Configuration loading
     When I attempt to configure a service with plural ports
     Then loading the configuration should fail with an argument error containing "Use 'port' instead of 'ports'"
 
+  Scenario: Programmatic configuration rejects reading plural service ports
+    When I attempt to read plural ports from a configured service
+    Then loading the configuration should fail with an argument error containing "Use 'port' instead of 'ports'"
+
   Scenario: YAML maps proxy options
     Given I load a temporary configuration with proxy options
     Then the configured service "service_1" proxy option "delay" should be 5
+
+  Scenario: YAML rejects process proxies
+    When I attempt to load a temporary configuration with a process proxy
+    Then loading the configuration should fail with an argument error containing "processes do not support 'proxy'"
+
+  Scenario: YAML rejects server proxies
+    When I attempt to load a temporary configuration with a server proxy
+    Then loading the configuration should fail with an argument error containing "servers do not support 'proxy'"
 
   Scenario: Server YAML class entries resolve to server implementations
     Given I load a temporary configuration with a server entry
@@ -44,7 +56,6 @@ Feature: Configuration loading
   Scenario: Missing hosts default to loopback
     Given I load a temporary configuration with omitted hosts
     Then the configured process "default_host_process" should use host "127.0.0.1"
-    And the configured process "default_host_process" proxy should use host "127.0.0.1"
 
   Scenario: YAML configuration does not evaluate ERB
     Given I load a temporary configuration containing ERB

--- a/features/processes.feature
+++ b/features/processes.feature
@@ -60,35 +60,3 @@ Feature: Process runners
     Then I should receive a TCP "test" response from the process
     And the YAML argv process shell side effect should not happen
     And the YAML process environment output should be "configured"
-
-  @proxy @reset
-  Scenario: A delayed process proxy still allows TCP responses
-    Given I configure the system programmatically with processes
-    And I start the system
-    And I set the proxy for process 'start_1' to 'delay'
-    When I send "test" with the TCP client to the processes
-    Then I should receive a TCP "test" response
-
-  @proxy @reset
-  Scenario: Closing the process proxy resets the TCP client
-    Given I configure the system programmatically with processes
-    And I start the system
-    And I set the proxy for process 'start_1' to 'close_all'
-    When I send "test" with the TCP client 'start_1' to the process
-    Then I should receive a connection error for client response with TCP
-
-  @proxy @reset
-  Scenario: Invalid proxy data changes the TCP client response
-    Given I configure the system programmatically with processes
-    And I start the system
-    And I set the proxy for process 'start_1' to 'invalid_data'
-    When I send "test" with the TCP client 'start_1' to the process
-    Then I should receive an invalid data response that is not "test" with TCP
-    And I should see a log entry of "Received line: 'test'" for process 'start_1'
-
-  @proxy
-  Scenario: Looking up a missing process proxy fails
-    Given I configure the system programmatically with processes
-    And I start the system
-    When I try to find the proxy for process 'non_existent'
-    Then I should get a proxy not found error

--- a/features/servers.feature
+++ b/features/servers.feature
@@ -1,6 +1,6 @@
 @acceptance @manual @clear
 Feature: Servers
-  Start configured servers, expose observability endpoints, and control server proxies.
+  Start configured servers and expose observability endpoints.
 
   Scenario Outline: TCP servers respond when configured <source>
     Given I configure the system <source> with servers
@@ -60,49 +60,13 @@ Feature: Servers
       | readiness |
       | metrics   |
 
+  Scenario: Server runners can be looked up by name
+    Given I configure the system programmatically with servers
+    And I start the system
+    When I look up the server runner "tcp_server_1"
+    Then I should find the server runner "tcp_server_1"
+
   @proxy @contract
   Scenario: Custom proxy kinds can be registered
     When I register a custom proxy kind
     Then the custom proxy kind should resolve to the custom proxy
-
-  @proxy @reset
-  Scenario: Closing the HTTP proxy breaks metrics requests
-    Given I configure the system programmatically with servers
-    And I start the system
-    And I set the proxy for server 'http_server_1' to 'close_all'
-    When I request metrics over HTTP
-    Then I should receive a connection error for metrics response with HTTP
-
-  @proxy @reset
-  Scenario Outline: HTTP hello requests fail when the proxy is set to <state>
-    Given I configure the system programmatically with servers
-    And I start the system
-    And I set the proxy for server 'http_server_1' to '<state>'
-    When I request hello over HTTP
-    Then I should receive the <failure> error for hello response with HTTP
-
-    Examples:
-      | state        | failure      |
-      | delay        | delay        |
-      | invalid_data | invalid data |
-
-  @proxy @reset
-  Scenario Outline: gRPC greetings fail when the proxy is set to <state>
-    Given I configure the system programmatically with servers
-    And I start the system
-    And I set the proxy for server 'grpc_server_1' to '<state>'
-    When I <request>
-    Then I should receive the <failure> error for being greeted with gRPC
-
-    Examples:
-      | state        | request                               | failure      |
-      | close_all    | greet over gRPC                       | connection   |
-      | delay        | greet over gRPC with a short deadline | delay        |
-      | invalid_data | greet over gRPC                       | invalid data |
-
-  @proxy
-  Scenario: Looking up a missing server proxy fails
-    Given I configure the system programmatically with servers
-    And I start the system
-    When I try to find the proxy for server 'non_existent'
-    Then I should get a proxy not found error

--- a/features/services.feature
+++ b/features/services.feature
@@ -17,6 +17,29 @@ Feature: Service proxies
       | source                |
       | through configuration |
 
+  Scenario: Service proxies expose the upstream endpoint
+    Given I configure the system programmatically with services
+    And I start the system
+    Then the proxy for service "service_1" should use host "127.0.0.1" and port 30000
+
+  @reset
+  Scenario: Services can run without proxies
+    Given I configure the system programmatically with services without proxies
+    And I start the system
+    When I connect to the service
+    And I send "test" to the service
+    And I receive data from the service
+    Then I should receive "test" from the service
+    And the proxy for service "service_1" should use host "127.0.0.1" and port 30000
+
+  Scenario: Missing proxy upstreams close service connections
+    Given I configure the system programmatically with services and missing upstreams
+    And I start the system
+    When I connect to the service
+    And I receive data from the service
+    Then I should receive a connection error from the service
+    And I should see a log entry of "could not handle the connection" in the file "test/reports/proxy_service_1.log"
+
   @reset
   Scenario: Closing the service proxy interrupts reads
     Given I configure the system programmatically with services
@@ -25,6 +48,26 @@ Feature: Service proxies
     When I connect to the service
     And I receive data from the service
     Then I should receive a connection error from the service
+
+  @reset
+  Scenario: A delayed service proxy still allows responses
+    Given I configure the system programmatically with services
+    And I start the system
+    And I set the proxy for service 'service_1' to 'delay'
+    When I connect to the service
+    And I send "test" to the service
+    And I receive data from the service
+    Then I should receive "test" from the service
+
+  @reset
+  Scenario: Invalid proxy data changes the service response
+    Given I configure the system programmatically with services
+    And I start the system
+    And I set the proxy for service 'service_1' to 'invalid_data'
+    When I connect to the service
+    And I send "test" to the service
+    And I receive data from the service
+    Then I should receive an invalid service response that is not "test"
 
   Scenario: Looking up a missing service proxy fails
     Given I configure the system programmatically with services

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -131,11 +131,53 @@ Given('I load a temporary configuration with omitted hosts') do
         ports:
           - 12400
         log: test/reports/12_400.log
-        proxy:
-          kind: fault_injection
-          port: 30000
-          log: test/reports/proxy_default_host_process.log
   YAML
+end
+
+When('I attempt to load a temporary configuration with a process proxy') do
+  @configuration_error = nil
+  capture_result(:@configuration_result, :@configuration_error) do
+    load_temporary_configuration(<<~YAML)
+      version: "1.0"
+      name: test
+      url: http://localhost:4567
+      log: test/reports/nonnative.log
+      processes:
+        - name: process_proxy
+          command: features/support/bin/start 12_400
+          timeout: 1
+          ports:
+            - 12400
+          log: test/reports/12_400.log
+          proxy:
+            kind: fault_injection
+            port: 30000
+            log: test/reports/proxy_process.log
+    YAML
+  end
+end
+
+When('I attempt to load a temporary configuration with a server proxy') do
+  @configuration_error = nil
+  capture_result(:@configuration_result, :@configuration_error) do
+    load_temporary_configuration(<<~YAML)
+      version: "1.0"
+      name: test
+      url: http://localhost:4567
+      log: test/reports/nonnative.log
+      servers:
+        - name: server_proxy
+          class: Nonnative::Features::TCPServer
+          timeout: 1
+          ports:
+            - 12400
+          log: test/reports/server_proxy.log
+          proxy:
+            kind: fault_injection
+            port: 30000
+            log: test/reports/proxy_server.log
+    YAML
+  end
 end
 
 When('I attempt to load a temporary configuration with a Ruby object tag') do
@@ -201,6 +243,20 @@ When('I attempt to configure a service with plural ports') do
   end
 end
 
+When('I attempt to read plural ports from a configured service') do
+  @configuration_error = nil
+  Nonnative.configure do |config|
+    config.service do |service|
+      service.name = 'legacy_ports_service'
+      service.port = 12_400
+    end
+  end
+
+  capture_result(:@configuration_result, :@configuration_error) do
+    configured_service('legacy_ports_service').ports
+  end
+end
+
 When('I attempt to load a temporary configuration with {string} YAML') do |kind|
   @configuration_error = nil
   capture_result(:@configuration_result, :@configuration_error) do
@@ -255,12 +311,6 @@ Then('the configured process {string} should use host {string}') do |name, host|
   process = configured_process(name)
 
   expect(process.host).to eq(host)
-end
-
-Then('the configured process {string} proxy should use host {string}') do |name, host|
-  process = configured_process(name)
-
-  expect(process.proxy.host).to eq(host)
 end
 
 Then('the ERB side effect should not happen') do

--- a/features/step_definitions/processes_steps.rb
+++ b/features/step_definitions/processes_steps.rb
@@ -107,10 +107,6 @@ When('I send {string} with the TCP client {string} to the process') do |message,
   @response = tcp_client_for_process(name).request(message)
 end
 
-When('I try to find the proxy for process {string}') do |name|
-  capture_result(:@process, :@error) { Nonnative.pool.process_by_name(name) }
-end
-
 Then('I should receive a TCP {string} response') do |response|
   @responses.each { |r| expect(r).to eq(response) }
 end
@@ -141,10 +137,6 @@ Then('the YAML process environment output should be {string}') do |value|
   expect(File.read(@yaml_environment_output_path)).to eq(value)
 end
 
-Then('I should receive a connection error for client response with TCP') do
-  expect(@response).to be_a Errno::ECONNRESET
-end
-
 After do
   @environment_process&.stop
 
@@ -153,10 +145,4 @@ After do
   @previous_environment.each do |name, value|
     value.nil? ? ENV.delete(name) : ENV[name] = value
   end
-end
-
-Then('I should receive an invalid data response that is not {string} with TCP') do |message|
-  expect(@response).to be_a(String)
-  expect(@response).not_to be_empty
-  expect(@response).not_to eq(message)
 end

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -43,17 +43,13 @@ When('I send a not found message with the HTTP client to the servers') do
   @response = http_client_for_server('http_server_1').not_found
 end
 
-When('I try to find the proxy for server {string}') do |name|
-  capture_result(:@server_runner, :@error) { Nonnative.pool.server_by_name(name) }
+When('I look up the server runner {string}') do |name|
+  @server_runner = Nonnative.pool.server_by_name(name)
 end
 
 When('I register a custom proxy kind') do
   @previous_custom_proxy = Nonnative.proxies['custom']
   Nonnative.proxies['custom'] = Nonnative::Features::CustomProxy
-end
-
-Then('I should get a proxy not found error') do
-  expect(@error).to be_a(Nonnative::NotFoundError)
 end
 
 Then('the custom proxy kind should resolve to the custom proxy') do
@@ -74,22 +70,6 @@ end
 
 When('I send a {string} request with body {string} to the local HTTP proxy server') do |verb, body|
   @response = http_client_for_server('local_http_proxy_server').inspect_request(verb.downcase, body)
-end
-
-When('I request metrics over HTTP') do
-  capture_result { Nonnative.observability.metrics }
-end
-
-When('I request hello over HTTP') do
-  capture_result { http_client_for_server('http_server_1').hello_get }
-end
-
-When('I greet over gRPC') do
-  capture_result { grpc_client_for_server('grpc_server_1').say_hello(greeter_request) }
-end
-
-When('I greet over gRPC with a short deadline') do
-  capture_result { grpc_client_for_server('grpc_server_1', timeout: 1).say_hello(greeter_request) }
 end
 
 Then('I should receive an HTTP {string} response') do |response|
@@ -115,30 +95,6 @@ Then('I should receive an HTTP not found response') do
   expect(@response.code).to eq(404)
 end
 
-Then('I should receive a connection error for metrics response with HTTP') do
-  expect(@error).to be_a(StandardError)
-end
-
-Then('I should receive the delay error for hello response with HTTP') do
-  expect(@error).to be_a(RestClient::Exceptions::ReadTimeout)
-end
-
-Then('I should receive the invalid data error for hello response with HTTP') do
-  expect(@error).to be_a(Net::HTTPBadResponse)
-end
-
-Then('I should receive the connection error for being greeted with gRPC') do
-  expect(@error).to be_a(GRPC::Unavailable)
-end
-
-Then('I should receive the delay error for being greeted with gRPC') do
-  expect(@error).to be_a(GRPC::DeadlineExceeded)
-end
-
-Then('I should receive the invalid data error for being greeted with gRPC') do
-  expect(@error).to be_a(StandardError)
-end
-
 Then('I should receive a successful response from the HTTP proxy server') do
   expect(@error).to be_nil
   expect(@response.code).to eq(200)
@@ -155,4 +111,8 @@ Then('I should receive the {string} request details from the local HTTP proxy se
   expect(@error).to be_nil
   expect(@response.code).to eq(200)
   expect(body).to match_inspected_proxy_request(verb, 'Hello World!')
+end
+
+Then('I should find the server runner {string}') do |name|
+  expect(@server_runner.name).to eq(name)
 end

--- a/features/step_definitions/services_steps.rb
+++ b/features/step_definitions/services_steps.rb
@@ -4,6 +4,14 @@ Given('I configure the system programmatically with services') do
   configure_services_programmatically
 end
 
+Given('I configure the system programmatically with services without proxies') do
+  configure_services_without_proxies_programmatically
+end
+
+Given('I configure the system programmatically with services and missing upstreams') do
+  configure_services_with_missing_upstreams_programmatically
+end
+
 Given('I configure the system through configuration with services') do
   load_configuration('features/configs/services.yml')
 end
@@ -31,6 +39,27 @@ end
 Then('I should receive a connection error from the service') do
   expect(@service_response).not_to be_a(String)
   expect(connection_error?(@service_response)).to be(true)
+end
+
+Then('I should receive {string} from the service') do |response|
+  expect(@service_response).to eq(response)
+end
+
+Then('I should receive an invalid service response that is not {string}') do |message|
+  expect(@service_response).to be_a(String)
+  expect(@service_response).not_to be_empty
+  expect(@service_response).not_to eq(message)
+end
+
+Then('I should get a proxy not found error') do
+  expect(@error).to be_a(Nonnative::NotFoundError)
+end
+
+Then('the proxy for service {string} should use host {string} and port {int}') do |name, host, port|
+  proxy = Nonnative.pool.service_by_name(name).proxy
+
+  expect(proxy.host).to eq(host)
+  expect(proxy.port).to eq(port)
 end
 
 Then('I should have a successful connection') do

--- a/features/support/context/benchmark_configuration.rb
+++ b/features/support/context/benchmark_configuration.rb
@@ -50,14 +50,7 @@ module Nonnative
               host: '127.0.0.1',
               ports: [14_006],
               log: 'test/reports/14_006.log',
-              signal: 'INT',
-              proxy: {
-                kind: 'fault_injection',
-                host: '127.0.0.1',
-                port: 24_006,
-                log: 'test/reports/proxy_14_006.log',
-                wait: 0.1
-              }
+              signal: 'INT'
             )
           end
         end

--- a/features/support/context/process_configuration.rb
+++ b/features/support/context/process_configuration.rb
@@ -7,21 +7,13 @@ module Nonnative
         PROCESSES = [
           {
             name: 'start_1',
-            command: -> { 'features/support/bin/start 20_005' },
+            command: -> { 'features/support/bin/start 12_321' },
             timeout: 5,
             host: '127.0.0.1',
             ports: [12_321],
             log: 'test/reports/12_321.log',
             signal: 'INT',
-            environment: { 'STRING' => 'true' },
-            proxy: {
-              kind: 'fault_injection',
-              host: '127.0.0.1',
-              port: 20_005,
-              log: 'test/reports/proxy_start_1.log',
-              wait: 1,
-              options: { delay: 10 }
-            }
+            environment: { 'STRING' => 'true' }
           },
           {
             name: 'start_2',
@@ -48,7 +40,7 @@ module Nonnative
         end
 
         def apply_process_definition(process, definition)
-          %i[name command timeout wait host ports log signal environment proxy].each do |attribute|
+          %i[name command timeout wait host ports log signal environment].each do |attribute|
             assign_process_attribute(process, definition, attribute)
           end
         end

--- a/features/support/context/server_configuration.rb
+++ b/features/support/context/server_configuration.rb
@@ -25,57 +25,28 @@ module Nonnative
             timeout: 1,
             host: '127.0.0.1',
             ports: [4567],
-            log: 'test/reports/http_server_1.log',
-            proxy: {
-              kind: 'fault_injection',
-              host: '127.0.0.1',
-              port: 20_001,
-              log: 'test/reports/proxy_http_server_1.log',
-              wait: 1,
-              options: { delay: 10 }
-            }
+            log: 'test/reports/http_server_1.log'
           },
           {
             name: 'http_server_2',
             klass: 'Nonnative::Features::HTTPServer',
             timeout: 1,
             ports: [4568],
-            log: 'test/reports/http_server_2.log',
-            proxy: {
-              kind: 'fault_injection',
-              port: 20_002,
-              log: 'test/reports/proxy_http_server_2.log',
-              wait: 1,
-              options: { delay: 2 }
-            }
+            log: 'test/reports/http_server_2.log'
           },
           {
             name: 'grpc_server_1',
             klass: 'Nonnative::Features::GRPCServer',
             timeout: 1,
             ports: [9002],
-            log: 'test/reports/grpc_server_1.log',
-            proxy: {
-              kind: 'fault_injection',
-              port: 20_003,
-              log: 'test/reports/proxy_grpc_server_1.log',
-              wait: 1,
-              options: { delay: 5 }
-            }
+            log: 'test/reports/grpc_server_1.log'
           },
           {
             name: 'grpc_server_2',
             klass: 'Nonnative::Features::GRPCServer',
             timeout: 1,
             ports: [9003],
-            log: 'test/reports/grpc_server_2.log',
-            proxy: {
-              kind: 'fault_injection',
-              port: 20_004,
-              log: 'test/reports/proxy_grpc_server_2.log',
-              wait: 1,
-              options: { delay: 7 }
-            }
+            log: 'test/reports/grpc_server_2.log'
           }
         ].freeze
 
@@ -98,7 +69,6 @@ module Nonnative
             server.host = definition[:host] if definition[:host]
             server.ports = definition[:ports]
             server.log = definition[:log]
-            server.proxy = definition[:proxy] if definition[:proxy]
           end
         end
 

--- a/features/support/context/service_configuration.rb
+++ b/features/support/context/service_configuration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 module Nonnative
   module Features
     module Context
@@ -14,8 +16,32 @@ module Nonnative
               host: '127.0.0.1',
               port: 30_000,
               log: 'test/reports/proxy_service_1.log',
-              wait: 1,
-              options: { delay: 7 }
+              wait: 0.1,
+              options: { delay: 0.1 }
+            }
+          }
+        ].freeze
+
+        NO_PROXY_SERVICES = [
+          {
+            name: 'service_1',
+            host: '127.0.0.1',
+            port: 30_000
+          }
+        ].freeze
+
+        MISSING_UPSTREAM_SERVICES = [
+          {
+            name: 'service_1',
+            host: '127.0.0.1',
+            port: 20_006,
+            proxy: {
+              kind: 'fault_injection',
+              host: '127.0.0.1',
+              port: 30_001,
+              log: 'test/reports/proxy_service_1.log',
+              wait: 0.1,
+              options: { delay: 0.1 }
             }
           }
         ].freeze
@@ -26,6 +52,20 @@ module Nonnative
           end
         end
 
+        def configure_services_without_proxies_programmatically
+          configure_with_defaults do |config|
+            NO_PROXY_SERVICES.each { |definition| add_service(config, definition) }
+          end
+        end
+
+        def configure_services_with_missing_upstreams_programmatically
+          FileUtils.rm_f(MISSING_UPSTREAM_SERVICES.first[:proxy][:log])
+
+          configure_with_defaults do |config|
+            MISSING_UPSTREAM_SERVICES.each { |definition| add_service(config, definition) }
+          end
+        end
+
         private
 
         def add_service(config, definition)
@@ -33,7 +73,7 @@ module Nonnative
             service.name = definition[:name]
             service.host = definition[:host]
             service.port = definition[:port]
-            service.proxy = definition[:proxy]
+            service.proxy = definition[:proxy] if definition[:proxy]
           end
         end
       end

--- a/features/support/service.rb
+++ b/features/support/service.rb
@@ -44,7 +44,9 @@ module Nonnative
       end
 
       def read_until_closed(socket)
-        socket.gets until socket.eof?
+        while (line = socket.gets)
+          socket.puts(line)
+        end
       rescue IOError, SystemCallError
         nil
       ensure
@@ -81,7 +83,7 @@ module Nonnative
       end
 
       def receive
-        @socket.gets
+        @socket.gets&.chomp
       rescue StandardError => e
         e
       end

--- a/features/support/tcp_server.rb
+++ b/features/support/tcp_server.rb
@@ -6,7 +6,7 @@ module Nonnative
       def initialize(service)
         super
 
-        @socket_server = ::TCPServer.new(proxy.host, proxy.port)
+        @socket_server = ::TCPServer.new(service.host, service.port)
       end
 
       def perform_start

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -124,13 +124,13 @@ module Nonnative
     def add_processes(cfg)
       processes = cfg.processes || []
       processes.each do |loaded_process|
+        reject_proxy(loaded_process, 'processes')
+
         process do |process_config|
           process_config.command = command(loaded_process)
           process_config.signal = loaded_process.signal
           process_config.environment = loaded_process.environment
           runner_attributes(process_config, loaded_process)
-
-          assign_proxy(process_config, loaded_process.proxy)
         end
       end
     end
@@ -150,11 +150,11 @@ module Nonnative
     def add_servers(cfg)
       servers = cfg.servers || []
       servers.each do |loaded_server|
+        reject_proxy(loaded_server, 'servers')
+
         server do |server_config|
           server_config.klass = Object.const_get(server_class_name(loaded_server))
           runner_attributes(server_config, loaded_server)
-
-          assign_proxy(server_config, loaded_server.proxy)
         end
       end
     end
@@ -200,7 +200,14 @@ module Nonnative
       service.port = loaded.port if loaded.port
     end
 
-    def assign_proxy(runner, loaded_proxy)
+    def reject_proxy(loaded, kind)
+      values = loaded.to_h
+      return unless values.key?(:proxy) || values.key?('proxy')
+
+      raise ArgumentError, "Use 'services' for proxy configuration; #{kind} do not support 'proxy'"
+    end
+
+    def assign_proxy(service, loaded_proxy)
       return unless loaded_proxy
 
       proxy_attributes = {
@@ -213,7 +220,7 @@ module Nonnative
       proxy_attributes[:host] = loaded_proxy.host if loaded_proxy.host
       proxy_attributes[:wait] = loaded_proxy.wait if loaded_proxy.wait
 
-      runner.proxy = proxy_attributes
+      service.proxy = proxy_attributes
     end
   end
 end

--- a/lib/nonnative/configuration_proxy.rb
+++ b/lib/nonnative/configuration_proxy.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 module Nonnative
-  # Proxy configuration attached to a runner configuration.
+  # Proxy configuration attached to a service configuration.
   #
   # A proxy allows you to interpose behavior between a client and a real service. For example,
   # the built-in `"fault_injection"` proxy can close connections, introduce delays, or corrupt data
   # for resilience testing.
   #
-  # This object is created automatically for each runner via {Nonnative::ConfigurationRunner}.
-  # When `kind` is set to `"none"`, no proxy is started and the runner will use its configured
+  # This object is created automatically for each service via {Nonnative::ConfigurationService}.
+  # When `kind` is set to `"none"`, no proxy is started and the service will use its configured
   # `host`/`port` directly.
   #
-  # @see Nonnative::ConfigurationRunner#proxy
+  # @see Nonnative::ConfigurationService#proxy
   # @see Nonnative.proxies
   class ConfigurationProxy
     # @return [String] proxy kind name (for example `"none"` or `"fault_injection"`)

--- a/lib/nonnative/configuration_runner.rb
+++ b/lib/nonnative/configuration_runner.rb
@@ -3,8 +3,7 @@
 module Nonnative
   # Base configuration for a runnable unit managed by Nonnative.
   #
-  # This class holds connection and timing attributes common to processes, servers and services,
-  # as well as a nested {Nonnative::ConfigurationProxy} describing how/if a proxy should be started.
+  # This class holds connection and timing attributes common to processes, servers and services.
   #
   # Instances of this type are typically created via {Nonnative::Configuration#process},
   # {Nonnative::Configuration#server}, or {Nonnative::Configuration#service}.
@@ -22,29 +21,18 @@ module Nonnative
     # @return [Array<Integer>] client-facing ports used for readiness/shutdown checks
     attr_reader :ports
 
-    # Proxy configuration for this runner.
-    #
-    # Note that this returns a configuration object even if no proxy is enabled; by default
-    # the proxy kind is `"none"`.
-    #
-    # @return [Nonnative::ConfigurationProxy]
-    attr_reader :proxy
-
     # Creates a runner configuration with defaults.
     #
     # Defaults:
     # - `host`: `"127.0.0.1"`
     # - `ports`: `[0]`
     # - `wait`: `0.1`
-    # - `proxy`: a new {Nonnative::ConfigurationProxy} with its own defaults
     #
     # @return [void]
     def initialize
       self.host = '127.0.0.1'
       @ports = [0]
       self.wait = 0.1
-
-      @proxy = Nonnative::ConfigurationProxy.new
     end
 
     # Sets the client-facing ports for this runner.
@@ -57,34 +45,11 @@ module Nonnative
 
     # Returns the primary client-facing port.
     #
-    # This preserves a single endpoint for proxy binding and client helpers while the public
-    # configuration contract uses {#ports}.
+    # This preserves a single endpoint for client helpers while the public configuration contract uses {#ports}.
     #
     # @return [Integer]
     def port
       ports.first
-    end
-
-    # Sets proxy configuration using a hash-like value.
-    #
-    # This is primarily used when loading YAML configuration files, where proxy attributes are
-    # represented as scalar values.
-    #
-    # @param value [Hash] proxy attributes
-    # @option value [String] :kind proxy kind name (for example `"fault_injection"`)
-    # @option value [String] :host upstream host behind the proxy (optional)
-    # @option value [Integer] :port upstream port behind the proxy
-    # @option value [String] :log proxy log file path
-    # @option value [Numeric] :wait wait interval (seconds) after state changes (optional)
-    # @option value [Hash] :options proxy implementation specific options
-    # @return [void]
-    def proxy=(value)
-      proxy.kind = value[:kind]
-      proxy.host = value[:host] if value[:host]
-      proxy.port = value[:port]
-      proxy.log = value[:log]
-      proxy.wait = value[:wait] if value[:wait]
-      proxy.options = value[:options]
     end
   end
 end

--- a/lib/nonnative/configuration_service.rb
+++ b/lib/nonnative/configuration_service.rb
@@ -14,6 +14,11 @@ module Nonnative
     # @return [Integer] client-facing port used by the service proxy
     attr_accessor :port
 
+    # Proxy configuration for this service.
+    #
+    # @return [Nonnative::ConfigurationProxy]
+    attr_reader :proxy
+
     # Creates a service configuration with defaults.
     #
     # @return [void]
@@ -21,6 +26,29 @@ module Nonnative
       super
 
       self.port = 0
+      @proxy = Nonnative::ConfigurationProxy.new
+    end
+
+    # Sets proxy configuration using a hash-like value.
+    #
+    # This is primarily used when loading YAML configuration files, where proxy attributes are
+    # represented as scalar values.
+    #
+    # @param value [Hash] proxy attributes
+    # @option value [String] :kind proxy kind name (for example `"fault_injection"`)
+    # @option value [String] :host upstream host behind the proxy (optional)
+    # @option value [Integer] :port upstream port behind the proxy
+    # @option value [String] :log proxy log file path
+    # @option value [Numeric] :wait wait interval (seconds) after state changes (optional)
+    # @option value [Hash] :options proxy implementation specific options
+    # @return [void]
+    def proxy=(value)
+      proxy.kind = value[:kind]
+      proxy.host = value[:host] if value[:host]
+      proxy.port = value[:port]
+      proxy.log = value[:log]
+      proxy.wait = value[:wait] if value[:wait]
+      proxy.options = value[:options]
     end
 
     # Services expose a single proxy listener, so plural runner ports are not supported.

--- a/lib/nonnative/cucumber.rb
+++ b/lib/nonnative/cucumber.rb
@@ -45,16 +45,6 @@ module Nonnative
       end
 
       def install_proxy_mutation_steps
-        Given('I set the proxy for process {string} to {string}') do |name, operation|
-          process = Nonnative.pool.process_by_name(name)
-          Nonnative::Cucumber::Registration.apply_proxy_operation(process.proxy, operation)
-        end
-
-        Given('I set the proxy for server {string} to {string}') do |name, operation|
-          server = Nonnative.pool.server_by_name(name)
-          Nonnative::Cucumber::Registration.apply_proxy_operation(server.proxy, operation)
-        end
-
         Given('I set the proxy for service {string} to {string}') do |name, operation|
           service = Nonnative.pool.service_by_name(name)
           Nonnative::Cucumber::Registration.apply_proxy_operation(service.proxy, operation)
@@ -62,16 +52,6 @@ module Nonnative
       end
 
       def install_proxy_reset_steps
-        Then('I should reset the proxy for process {string}') do |name|
-          process = Nonnative.pool.process_by_name(name)
-          process.proxy.reset
-        end
-
-        Then('I should reset the proxy for server {string}') do |name|
-          server = Nonnative.pool.server_by_name(name)
-          server.proxy.reset
-        end
-
         Then('I should reset the proxy for service {string}') do |name|
           service = Nonnative.pool.service_by_name(name)
           service.proxy.reset

--- a/lib/nonnative/fault_injection_proxy.rb
+++ b/lib/nonnative/fault_injection_proxy.rb
@@ -18,12 +18,12 @@ module Nonnative
   #
   # ## Wiring
   #
-  # When enabled, your test/client should connect to the runner `host` and primary port (the proxy
+  # When enabled, your test/client should connect to the service `host` and `port` (the proxy
   # endpoint), and the proxy will forward traffic to the upstream target exposed by {#host}:{#port}.
   #
   # ## Configuration
   #
-  # The proxy is configured via the runner’s `proxy` hash:
+  # The proxy is configured via the service's `proxy` hash:
   #
   # - `kind`: `"fault_injection"`
   # - `host` / `port`: upstream target behind the proxy (exposed via {#host}/{#port})
@@ -50,7 +50,7 @@ module Nonnative
       end
     end
 
-    # @param service [Nonnative::ConfigurationRunner] runner configuration with proxy settings
+    # @param service [Nonnative::ConfigurationService] service configuration with proxy settings
     def initialize(service)
       @connections = Concurrent::Hash.new
       @logger = Logger.new(service.proxy.log)
@@ -62,8 +62,8 @@ module Nonnative
 
     # Starts the proxy accept loop in a background thread.
     #
-    # This binds a TCP server on the underlying runner’s `service.host` and primary port.
-    # Clients connect to that runner endpoint, while upstream traffic is forwarded to {#host}:{#port}.
+    # This binds a TCP server on the service `host` and `port`.
+    # Clients connect to that service endpoint, while upstream traffic is forwarded to {#host}:{#port}.
     #
     # @return [void]
     def start

--- a/lib/nonnative/grpc_server.rb
+++ b/lib/nonnative/grpc_server.rb
@@ -4,8 +4,7 @@ module Nonnative
   # gRPC server runner implemented using {GRPC::RpcServer}.
   #
   # This is a convenience server implementation for running a gRPC service in-process under
-  # Nonnative's server lifecycle. It binds to the configured proxy `host`/`port` and is started/stopped
-  # by {Nonnative::Server} via {#perform_start} / {#perform_stop}.
+  # Nonnative's server lifecycle. It binds to the configured server `host` and first `ports` entry.
   #
   # Important note about logging: the `grpc` gem uses a global logger. This implementation sets
   # `GRPC.logger` to write to the configured `service.log`, and whichever gRPC server is initialized
@@ -33,12 +32,11 @@ module Nonnative
 
     # Binds the gRPC server and begins serving requests.
     #
-    # The server binds to the upstream proxy host/port so the fault-injection proxy can expose the
-    # runner host and first configured port as the client-facing endpoint used by readiness checks.
+    # The server binds to the configured server host and first configured port.
     #
     # @return [void]
     def perform_start
-      server.add_http2_port("#{proxy.host}:#{proxy.port}", :this_port_is_insecure)
+      server.add_http2_port("#{service.host}:#{service.port}", :this_port_is_insecure)
       server.run
     end
 

--- a/lib/nonnative/http_server.rb
+++ b/lib/nonnative/http_server.rb
@@ -4,8 +4,7 @@ module Nonnative
   # Puma-based HTTP server runner.
   #
   # This is a convenience server implementation for running a Rack/Sinatra application in-process
-  # under Nonnative's server lifecycle. It binds to the configured proxy `host`/`port` (so it works
-  # consistently with proxy configuration) and uses Puma for HTTP serving.
+  # under Nonnative's server lifecycle. It binds to the configured server `host` and first `ports` entry.
   #
   # The server is started and stopped by {Nonnative::Server} via {#perform_start} / {#perform_stop}.
   #
@@ -48,12 +47,11 @@ module Nonnative
 
     # Binds the Puma server and begins serving.
     #
-    # The listener binds to the upstream proxy host/port so the fault-injection proxy can expose the
-    # runner host and first configured port as the client-facing endpoint used by readiness checks.
+    # The listener binds to the configured server host and first configured port.
     #
     # @return [void]
     def perform_start
-      server.add_tcp_listener proxy.host, proxy.port
+      server.add_tcp_listener service.host, service.port
       server.run false
     end
 

--- a/lib/nonnative/no_proxy.rb
+++ b/lib/nonnative/no_proxy.rb
@@ -7,7 +7,7 @@ module Nonnative
   # It does not bind/listen or alter traffic; it simply exposes the underlying runner's configured
   # `host` and primary `port`.
   #
-  # Runners can always call `start`, `stop`, and `reset` safely on this proxy.
+  # Services can always call `start`, `stop`, and `reset` safely on this proxy.
   #
   # @see Nonnative.proxy
   # @see Nonnative::Proxy

--- a/lib/nonnative/pool.rb
+++ b/lib/nonnative/pool.rb
@@ -104,15 +104,13 @@ module Nonnative
       services[runner_index(configuration.services, name)]
     end
 
-    # Resets proxies for all runners in this pool.
+    # Resets service proxies in this pool.
     #
     # This is used by the Cucumber `@reset` hook and is safe to call any time after the pool is created.
     #
     # @return [void]
     def reset
       services.each { |s| s.proxy.reset }
-      servers.each { |s| s.first.proxy.reset }
-      processes.each { |p| p.first.proxy.reset }
     end
 
     private

--- a/lib/nonnative/process.rb
+++ b/lib/nonnative/process.rb
@@ -4,7 +4,6 @@ module Nonnative
   # Runtime runner that manages an OS-level child process.
   #
   # A process runner:
-  # - starts the configured proxy (if any),
   # - spawns a child process using the configured command and environment,
   # - waits briefly (via the runner `wait`), and
   # - participates in readiness/shutdown via TCP port checks orchestrated by {Nonnative::Pool}.
@@ -21,7 +20,7 @@ module Nonnative
       @timeout = Nonnative::Timeout.new(service.timeout)
     end
 
-    # Starts the proxy (if any) and spawns the configured process if it is not already running.
+    # Spawns the configured process if it is not already running.
     #
     # @return [Array<(Integer, Boolean)>]
     #   a tuple of:
@@ -29,7 +28,6 @@ module Nonnative
     #   - whether the process appears to still be running (non-blocking wait result)
     def start
       unless process_exists?
-        proxy.start
         @pid = process_spawn
         wait_start
       end
@@ -37,7 +35,7 @@ module Nonnative
       [pid, ::Process.waitpid2(pid, ::Process::WNOHANG).nil?]
     end
 
-    # Stops the process (if running) and stops the proxy (if any).
+    # Stops the process if it is running.
     #
     # The process is signalled using the configured signal (defaults to `INT` when not set).
     #
@@ -54,8 +52,6 @@ module Nonnative
       end
 
       [pid, stopped]
-    ensure
-      proxy.stop
     end
 
     # Returns a memoized memory reader for the spawned process.

--- a/lib/nonnative/proxy.rb
+++ b/lib/nonnative/proxy.rb
@@ -4,8 +4,7 @@ module Nonnative
   # Base class for proxy implementations.
   #
   # A proxy is responsible for interposing behavior between a client and a target service.
-  # Runners ({Nonnative::Process}, {Nonnative::Server}, and {Nonnative::Service}) create a proxy
-  # instance via {Nonnative::ProxyFactory} based on `service.proxy.kind`.
+  # Runtime services create a proxy instance via {Nonnative::ProxyFactory} based on `service.proxy.kind`.
   #
   # Concrete proxies typically implement these public methods:
   # - `start`: begin proxying (bind/listen, start threads, etc)
@@ -17,7 +16,7 @@ module Nonnative
   # @see Nonnative::NoProxy
   # @see Nonnative::FaultInjectionProxy
   class Proxy
-    # @param service [Nonnative::ConfigurationRunner] runner configuration with an attached proxy configuration
+    # @param service [Nonnative::ConfigurationService] service configuration with an attached proxy configuration
     def initialize(service)
       @service = service
     end

--- a/lib/nonnative/proxy_factory.rb
+++ b/lib/nonnative/proxy_factory.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 module Nonnative
-  # Factory for creating proxy instances for runners.
+  # Factory for creating proxy instances for services.
   #
-  # Each runtime runner ({Nonnative::Process}, {Nonnative::Server}, {Nonnative::Service}) constructs
-  # a proxy via this factory. The proxy implementation is selected by `service.proxy.kind` and resolved
-  # using {Nonnative.proxy}.
+  # A runtime service constructs a proxy via this factory. The proxy implementation is selected by
+  # `service.proxy.kind` and resolved using {Nonnative.proxy}.
   #
   # If the kind is unknown (or `"none"`), {Nonnative.proxy} returns {Nonnative::NoProxy}.
   #
@@ -15,9 +14,9 @@ module Nonnative
   # @see Nonnative::NoProxy
   class ProxyFactory
     class << self
-      # Creates a proxy instance for the given runner configuration.
+      # Creates a proxy instance for the given service configuration.
       #
-      # @param service [Nonnative::ConfigurationRunner] runner configuration with an attached proxy configuration
+      # @param service [Nonnative::ConfigurationService] service configuration with an attached proxy configuration
       # @return [Nonnative::Proxy] proxy instance (may be a {Nonnative::NoProxy})
       def create(service)
         proxy = Nonnative.proxy(service.proxy.kind)

--- a/lib/nonnative/runner.rb
+++ b/lib/nonnative/runner.rb
@@ -10,21 +10,13 @@ module Nonnative
   # - {Nonnative::Server} for in-process Ruby servers (threads)
   # - {Nonnative::Service} for proxy-only external dependencies
   #
-  # Each runner has an associated proxy instance created via {Nonnative::ProxyFactory}.
-  #
   # @see Nonnative::Process
   # @see Nonnative::Server
   # @see Nonnative::Service
   class Runner
-    # Returns the proxy instance for this runner.
-    #
-    # @return [Nonnative::Proxy]
-    attr_reader :proxy
-
     # @param service [Nonnative::ConfigurationRunner] runner configuration
     def initialize(service)
       @service = service
-      @proxy = Nonnative::ProxyFactory.create(service)
     end
 
     # Returns the configured runner name.

--- a/lib/nonnative/server.rb
+++ b/lib/nonnative/server.rb
@@ -4,7 +4,6 @@ module Nonnative
   # Runtime runner that manages an in-process Ruby server.
   #
   # A server runner:
-  # - starts the configured proxy (if any),
   # - starts a Ruby thread that runs {#perform_start},
   # - waits briefly (via the runner `wait`), and
   # - participates in readiness/shutdown via TCP port checks orchestrated by {Nonnative::Pool}.
@@ -25,7 +24,7 @@ module Nonnative
       @timeout = Nonnative::Timeout.new(service.timeout)
     end
 
-    # Starts the proxy (if any) and starts the server thread if not already started.
+    # Starts the server thread if it is not already started.
     #
     # @return [Array<(Integer, TrueClass)>]
     #   a tuple of:
@@ -33,7 +32,6 @@ module Nonnative
     #   - `true` (thread creation itself is considered started; readiness is checked separately)
     def start
       unless thread
-        proxy.start
         @thread = Thread.new { perform_start }
 
         wait_start
@@ -46,14 +44,13 @@ module Nonnative
 
     # Stops the server if it is running.
     #
-    # Calls {#perform_stop}, terminates the server thread, stops the proxy (if any), and waits briefly.
+    # Calls {#perform_stop}, terminates the server thread, and waits briefly.
     #
     # @return [Integer] the server identifier (`object_id`)
     def stop
       if thread
         perform_stop
         thread.terminate
-        proxy.stop
 
         @thread = nil
         wait_stop

--- a/lib/nonnative/service.rb
+++ b/lib/nonnative/service.rb
@@ -12,6 +12,18 @@ module Nonnative
   # @see Nonnative::ConfigurationService
   # @see Nonnative::Proxy
   class Service < Runner
+    # Returns the proxy instance for this service.
+    #
+    # @return [Nonnative::Proxy]
+    attr_reader :proxy
+
+    # @param service [Nonnative::ConfigurationService] service configuration
+    def initialize(service)
+      super
+
+      @proxy = Nonnative::ProxyFactory.create(service)
+    end
+
     # Starts the configured proxy (if any).
     #
     # @return [void]

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.1.0'
+  VERSION = '3.2.0'
 end


### PR DESCRIPTION
## What

- Limit fault-injection support to service runners; processes and servers now run directly without owning proxy instances.
- Reject `proxy:` under YAML `processes:` and `servers:` while keeping service proxy configuration unchanged.
- Remove process/server Cucumber proxy steps and examples, update server fixtures to bind to their configured host/port, and bump the gem version to 3.2.0.
- Update README guidance so plain services are introduced separately from service proxy configuration and Cucumber proxy steps.

## Why

- Services are the only runner type that represents an externally managed dependency, so they are the natural place for TCP fault injection.
- Removing process/server proxy support avoids mixing lifecycle ownership with network interposition and makes endpoint configuration easier to reason about.
- This is an intentional v3 breaking change: callers that need fault injection should model the dependency as a service proxy.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
