### PR TITLE
fix(proxy): prevent concurrent connection registry failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.2.0)
+    nonnative (3.2.1)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/features/services.feature
+++ b/features/services.feature
@@ -49,6 +49,12 @@ Feature: Service proxies
     And I receive data from the service
     Then I should receive a connection error from the service
 
+  Scenario: Stopping a service proxy while clients connect succeeds
+    Given I configure the system programmatically with services
+    And I start the system
+    When I stop the service runner "service_1" while clients connect
+    Then stopping the service runner should succeed
+
   @reset
   Scenario: A delayed service proxy still allows responses
     Given I configure the system programmatically with services

--- a/features/step_definitions/services_steps.rb
+++ b/features/step_definitions/services_steps.rb
@@ -28,6 +28,19 @@ When('I stop the service runner {string}') do |name|
   Nonnative.pool.service_by_name(name).stop
 end
 
+When('I stop the service runner {string} while clients connect') do |name|
+  service = configured_service(name)
+  runner = Nonnative.pool.service_by_name(name)
+  @stop_error = nil
+
+  20.times do |iteration|
+    runner.start if iteration.positive?
+    stop_service_runner_while_clients_connect(runner, service)
+
+    break if @stop_error
+  end
+end
+
 When('I receive data from the service') do
   @service_response = @service.receive
 end
@@ -53,6 +66,10 @@ end
 
 Then('I should get a proxy not found error') do
   expect(@error).to be_a(Nonnative::NotFoundError)
+end
+
+Then('stopping the service runner should succeed') do
+  expect(@stop_error).to be_nil
 end
 
 Then('the proxy for service {string} should use host {string} and port {int}') do |name, host, port|

--- a/features/support/context.rb
+++ b/features/support/context.rb
@@ -6,6 +6,7 @@ require_relative 'context/process_configuration'
 require_relative 'context/server_configuration'
 require_relative 'context/http_proxy_configuration'
 require_relative 'context/service_configuration'
+require_relative 'context/service_connections'
 require_relative 'context/benchmark_configuration'
 require_relative 'context/endpoint_clients'
 require_relative 'context/lifecycle_support'
@@ -25,6 +26,7 @@ module Nonnative
       include ServerConfiguration
       include HTTPProxyConfiguration
       include ServiceConfiguration
+      include ServiceConnections
       include BenchmarkConfiguration
       include EndpointClients
       include LifecycleSupport

--- a/features/support/context/service_connections.rb
+++ b/features/support/context/service_connections.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Nonnative
+  module Features
+    module Context
+      module ServiceConnections
+        def stop_service_runner_while_clients_connect(runner, service)
+          connections = open_service_connections(service, 20)
+          mutex = Mutex.new
+          stop_connecting = false
+          connector = connect_to_service_until_stopped(service, connections, mutex, -> { stop_connecting })
+
+          begin
+            sleep 0.05
+            capture_result(:@stop_result, :@stop_error) { runner.stop }
+          ensure
+            stop_connecting = true
+            connector&.join
+            close_service_connections(connections, mutex)
+          end
+        end
+
+        private
+
+        def open_service_connections(service, count)
+          Array.new(count).filter_map { open_service_connection(service) }
+        end
+
+        def connect_to_service_until_stopped(service, connections, mutex, stopped)
+          Thread.new do
+            50.times do
+              break if stopped.call
+
+              socket = open_service_connection(service)
+              mutex.synchronize { connections << socket } if socket
+              sleep 0.001
+            end
+          end
+        end
+
+        def open_service_connection(service)
+          TCPSocket.open(service.host, service.port)
+        rescue SystemCallError, IOError
+          nil
+        end
+
+        def close_service_connections(connections, mutex)
+          mutex.synchronize { connections.each { |socket| close_service_connection(socket) } }
+        end
+
+        def close_service_connection(socket)
+          socket.close unless socket.closed?
+        rescue IOError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/nonnative/fault_injection_proxy.rb
+++ b/lib/nonnative/fault_injection_proxy.rb
@@ -77,17 +77,16 @@ module Nonnative
     #
     # @return [void]
     def stop
-      mutex.synchronize do
-        close_connections
-      end
-
-      server = @tcp_server
-      @tcp_server = nil
+      server = tcp_server
       server&.close
 
-      listener_thread = @thread
-      @thread = nil
+      listener_thread = thread
       listener_thread&.join
+
+      @tcp_server = nil
+      @thread = nil
+
+      close_connections
 
       Nonnative.logger.info "stopped with host '#{service.host}' and port '#{service.port}' for proxy 'fault_injection'"
     end
@@ -162,7 +161,7 @@ module Nonnative
         logger.info "handled connection for '#{id}' with socket '#{socket.inspect}'"
       end
 
-      connections.delete(id)
+      delete_connection(id)
     end
 
     def connect(id, socket)
@@ -179,24 +178,26 @@ module Nonnative
     end
 
     def close_connections
-      connections.each do |id, connection|
+      active_connections = mutex.synchronize do
+        connections.to_a.tap { connections.clear }
+      end
+
+      active_connections.each do |id, connection|
         close_connection(id, connection)
       end
-    ensure
-      connections.clear
     end
 
     def apply_state(state)
-      mutex.synchronize do
-        Nonnative.logger.info "applying state '#{state}' for proxy 'fault_injection'"
+      Nonnative.logger.info "applying state '#{state}' for proxy 'fault_injection'"
 
+      mutex.synchronize do
         return if @state == state
 
         @state = state
-        close_connections
-
-        wait
       end
+
+      close_connections
+      wait
     end
 
     def read_state
@@ -204,15 +205,19 @@ module Nonnative
     end
 
     def register_connection(id, socket)
-      connections[id] = Connection.new(socket)
+      mutex.synchronize { connections[id] = Connection.new(socket) }
     end
 
     def attach_connection_thread(id, thread)
-      connections[id]&.thread = thread
+      mutex.synchronize { connections[id]&.thread = thread }
     end
 
     def attach_connection_pair(id, pair)
-      connections[id]&.pair = pair
+      mutex.synchronize { connections[id]&.pair = pair }
+    end
+
+    def delete_connection(id)
+      mutex.synchronize { connections.delete(id) }
     end
 
     def close_connection(id, connection)

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.2.0'
+  VERSION = '3.2.1'
 end


### PR DESCRIPTION
## What

- Prevent fault-injection service shutdown from mutating active connection tracking while it is being drained.
- Add Cucumber coverage for stopping a service runner while clients connect.
- Bump the gem version to 3.2.1.

## Why

- Concurrent client reconnects during shutdown could crash the accept thread and surface a Nonnative::StopError.
- Keeping connection tracking synchronized makes service runner teardown reliable for downstream suites with reconnecting clients.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- `make sec` - passed
- The new service scenario covers the stop/connect race that previously raised `cannot add a new key into hash during iteration`.
