### PR TITLE
docs(readme): clarify public api guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Nonnative.configure do |config|
 
   config.process do |p|
     p.name = 'start_1'
-    p.command = -> { ['features/support/bin/start', '12_321'] }
+    p.command = -> { ['bin/start-test-service', '12_321'] }
     p.timeout = 5
     p.wait = 0.1
     p.ports = [12_321]
@@ -177,7 +177,7 @@ Nonnative.configure do |config|
 
   config.process do |p|
     p.name = 'start_2'
-    p.command = -> { ['features/support/bin/start', '12_322'] }
+    p.command = -> { ['bin/start-test-service', '12_322'] }
     p.timeout = 0.5
     p.wait = 0.1
     p.ports = [12_322]
@@ -197,7 +197,7 @@ processes:
   -
     name: start_1
     command:
-      - features/support/bin/start
+      - bin/start-test-service
       - "12_321"
     timeout: 5
     wait: 1
@@ -210,7 +210,7 @@ processes:
   -
     name: start_2
     command:
-      - features/support/bin/start
+      - bin/start-test-service
       - "12_322"
     timeout: 5
     wait: 1
@@ -474,6 +474,8 @@ end
 
 Define your server:
 
+Assume the gRPC service base class and response types below come from your generated gRPC stubs.
+
 ```ruby
 module Nonnative
   module Features
@@ -529,6 +531,9 @@ servers:
       - 9002
     log: grpc_server_1.log
 ```
+
+The `grpc` gem uses a global logger, so per-server gRPC log files are not independent. The first
+initialized gRPC server sets the logger used by later gRPC servers in the same Ruby process.
 
 Then load the file with:
 

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -36,10 +36,10 @@
 #   # run tests...
 #   Nonnative.stop
 #
-# == Notes
+# == Cucumber integration
 #
-# This file also requires integration helpers used by acceptance tests. If you require `nonnative` outside a
-# Cucumber runtime, loading `nonnative/cucumber` may not be desirable for your environment.
+# Requiring `nonnative` loads the lazy Cucumber integration. It is safe outside a booted Cucumber
+# runtime; hooks and step definitions are installed once Cucumber's Ruby DSL is ready.
 #
 require 'socket'
 require 'timeout'

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -42,13 +42,25 @@ module Nonnative
     end
 
     # @return [String, nil] logical system name (used for observability endpoints)
+    attr_accessor :name
+
     # @return [String, nil] configuration version
+    attr_accessor :version
+
     # @return [String, nil] base URL for observability queries (for example `"http://127.0.0.1:8080"`)
+    attr_accessor :url
+
     # @return [String, nil] path to the Nonnative log file
+    attr_accessor :log
+
     # @return [Array<Nonnative::ConfigurationProcess>] configured processes
+    attr_accessor :processes
+
     # @return [Array<Nonnative::ConfigurationServer>] configured in-process servers
+    attr_accessor :servers
+
     # @return [Array<Nonnative::ConfigurationService>] configured services (proxy-only)
-    attr_accessor :name, :version, :url, :log, :processes, :servers, :services
+    attr_accessor :services
 
     # Loads a configuration file and appends its runners to this instance.
     #

--- a/lib/nonnative/configuration_proxy.rb
+++ b/lib/nonnative/configuration_proxy.rb
@@ -15,12 +15,21 @@ module Nonnative
   # @see Nonnative.proxies
   class ConfigurationProxy
     # @return [String] proxy kind name (for example `"none"` or `"fault_injection"`)
+    attr_accessor :kind
+
     # @return [String] upstream host used by proxy implementations (defaults to `"127.0.0.1"`)
+    attr_accessor :host
+
     # @return [Integer] upstream port used by proxy implementations (defaults to `0`)
+    attr_accessor :port
+
     # @return [String, nil] path to proxy log file (implementation-dependent)
+    attr_accessor :log
+
     # @return [Numeric] wait interval (seconds) after proxy state changes (defaults to `0.1`)
+    attr_accessor :wait
+
     # @return [Hash] proxy implementation options (implementation-dependent)
-    attr_accessor :kind, :host, :port, :log, :wait
     attr_reader :options
 
     # Creates a proxy configuration with defaults.

--- a/lib/nonnative/configuration_runner.rb
+++ b/lib/nonnative/configuration_runner.rb
@@ -13,10 +13,13 @@ module Nonnative
   # @see Nonnative::ConfigurationService
   class ConfigurationRunner
     # @return [String, nil] runner name used for lookup (for example via `pool.process_by_name`)
+    attr_accessor :name
+
     # @return [String] host to bind/connect to (defaults to `"127.0.0.1"`)
-    # @return [Array<Integer>] ports to bind/connect to
+    attr_accessor :host
+
     # @return [Numeric] wait interval (seconds) used by runners between lifecycle steps
-    attr_accessor :name, :host, :wait
+    attr_accessor :wait
 
     # @return [Array<Integer>] client-facing ports used for readiness/shutdown checks
     attr_reader :ports

--- a/lib/nonnative/configuration_server.rb
+++ b/lib/nonnative/configuration_server.rb
@@ -11,9 +11,13 @@ module Nonnative
   # @see Nonnative::Configuration
   # @see Nonnative::Server
   class ConfigurationServer < ConfigurationRunner
-    # @return [Class] a class that implements `#initialize(service)`, and lifecycle hooks expected by {Nonnative::Server}
+    # @return [Class] a class that implements `#initialize(service)` and the hooks expected by {Nonnative::Server}
+    attr_accessor :klass
+
     # @return [Numeric] readiness timeout (seconds) used when waiting for ports to open/close
+    attr_accessor :timeout
+
     # @return [String] log file path used by server implementations (for example Puma/gRPC log files)
-    attr_accessor :klass, :timeout, :log
+    attr_accessor :log
   end
 end

--- a/lib/nonnative/cucumber.rb
+++ b/lib/nonnative/cucumber.rb
@@ -8,6 +8,26 @@ module Nonnative
   # Requiring `nonnative` outside a running Cucumber environment should not fail, but when Cucumber
   # does finish booting its support-code registry this installer still needs to register the hooks
   # and step definitions defined here.
+  #
+  # Supported hooks:
+  # - `@startup`: start before scenario, stop after scenario
+  # - `@manual`: stop after scenario; use `When I start the system` to start manually
+  # - `@clear`: clear memoized Nonnative state before scenario
+  # - `@reset`: reset proxies after scenario
+  #
+  # Installed step definitions:
+  # - `Given I set the proxy for service {string} to {string}`
+  # - `Then I should reset the proxy for service {string}`
+  # - `When I start the system`
+  # - `When I attempt to start the system`
+  # - `When I attempt to stop the system`
+  # - `Then I should see {string} as unhealthy`
+  # - `Then I should see {string} as healthy`
+  # - `Then the process {string} should consume less than {string} of memory`
+  # - `Then starting the system should raise an error`
+  # - `Then stopping the system should raise an error`
+  # - `Then I should see a log entry of {string} for process {string}`
+  # - `Then I should see a log entry of {string} in the file {string}`
   module Cucumber
     module LanguageHook
       def rb_language=(value)

--- a/lib/nonnative/fault_injection_proxy.rb
+++ b/lib/nonnative/fault_injection_proxy.rb
@@ -11,7 +11,7 @@ module Nonnative
   #
   # - {#close_all}: close connections immediately on accept
   # - {#delay}: delay reads by a configured duration (default: 2 seconds)
-  # - {#invalid_data}: corrupt outbound data by shuffling characters
+  # - {#invalid_data}: forward requests unchanged and mutate upstream responses before they reach clients
   # - {#reset}: return to healthy pass-through behavior
   #
   # State changes terminate any active connections so new connections observe the new behavior.
@@ -107,7 +107,7 @@ module Nonnative
       apply_state :delay
     end
 
-    # Corrupts forwarded data by shuffling characters.
+    # Mutates upstream responses while forwarding client requests unchanged.
     #
     # @return [void]
     def invalid_data

--- a/lib/nonnative/http_server.rb
+++ b/lib/nonnative/http_server.rb
@@ -9,14 +9,20 @@ module Nonnative
   # The server is started and stopped by {Nonnative::Server} via {#perform_start} / {#perform_stop}.
   #
   # @example Running a Sinatra app
-  #   app = Sinatra.new do
-  #     get('/hello') { 'Hello World!' }
+  #   class HelloHTTPServer < Nonnative::HTTPServer
+  #     def initialize(service)
+  #       app = Sinatra.new do
+  #         get('/hello') { 'Hello World!' }
+  #       end
+  #
+  #       super(app, service)
+  #     end
   #   end
   #
   #   Nonnative.configure do |config|
   #     config.server do |s|
   #       s.name = 'http'
-  #       s.klass = ->(service) { Nonnative::HTTPServer.new(app, service) }
+  #       s.klass = HelloHTTPServer
   #       s.timeout = 2
   #       s.host = '127.0.0.1'
   #       s.ports = [4567]
@@ -24,7 +30,7 @@ module Nonnative
   #     end
   #   end
   #
-  # Note: In YAML configuration you typically set `class` to a concrete subclass that calls `super(app, service)`.
+  # YAML configuration uses the same concrete subclass name in its `class` field.
   #
   # @see Nonnative::Server
   class HTTPServer < Nonnative::Server

--- a/lib/nonnative/proxy.rb
+++ b/lib/nonnative/proxy.rb
@@ -6,11 +6,14 @@ module Nonnative
   # A proxy is responsible for interposing behavior between a client and a target service.
   # Runtime services create a proxy instance via {Nonnative::ProxyFactory} based on `service.proxy.kind`.
   #
+  # Service configuration `host` and `port` are the client-facing endpoint. Concrete proxy methods are
+  # implementation-specific; for example {Nonnative::FaultInjectionProxy#host} and
+  # {Nonnative::FaultInjectionProxy#port} return the upstream target behind the proxy.
+  #
   # Concrete proxies typically implement these public methods:
   # - `start`: begin proxying (bind/listen, start threads, etc)
   # - `stop`: stop proxying and release resources
   # - `reset`: return proxy behavior to a healthy/default state
-  # - `host` / `port`: endpoint clients should connect to when the proxy is enabled
   #
   # @see Nonnative::ProxyFactory
   # @see Nonnative::NoProxy


### PR DESCRIPTION
## What

- Clarify public examples so process commands are consumer-owned placeholders instead of repository-only fixtures.
- Document the generated gRPC stub prerequisite and the global gRPC logger limitation.
- Align RDoc for lazy Cucumber loading, shipped Cucumber steps, HTTP server subclassing, service proxy endpoints, invalid-data behavior, and configuration accessors.

## Why

- The previous public guidance mixed package-facing examples with repository fixtures and left several supported APIs or lifecycle surfaces discoverable only by reading implementation code.
- These updates make the documented contracts easier for downstream users to copy, extend, and preserve without accidentally bypassing proxies or relying on unsupported examples.

## Testing

- `make lint` - passed
- `make features` - passed, covering 75 scenarios and 260 steps across command, configuration, lifecycle, process, server, and service proxy behavior.
