### PR TITLE
build(bin): refresh shared tooling guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,6 @@ of dependencies.
 
 ## Intentional Design Choices
 
-- Root `make` compatibility is GNU Make 4+/`gmake` oriented through the shared
-  `bin/build/make/*.mak` fragments. Do not flag GNU Make 3.81 parsing failures
-  as code issues unless the task is explicitly about supporting GNU Make 3.81.
 - The configured HTTP proxy feature intentionally uses the external
   `www.afalkowski.com` host through `features/support/http_proxy_server.rb`.
   Do not flag this external dependency as a code issue unless the task is


### PR DESCRIPTION
## What

- Updates the `bin` submodule to the merged shared project-gap guidance changes.
- Removes local `AGENTS.md` exception text that is now covered by shared `bin/AGENTS.md`.

## Why

- Keeps downstream project-gap investigations focused on repository-specific issues instead of repeating shared workflow exceptions.
- Reduces duplicated maintainer guidance across repositories while preserving repo-specific notes.

## Testing

- `git diff --check` - passed
- `make help` - passed
- `make lint` - passed
