### PR TITLE
feat(http): strip forwarded proxy credentials

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.2.1)
+    nonnative (3.3.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/features/http_proxies.feature
+++ b/features/http_proxies.feature
@@ -15,6 +15,12 @@ Feature: HTTP proxies
       | PATCH  |
       | DELETE |
 
+  Scenario: The local HTTP proxy does not forward proxy credentials
+    Given I configure the system programmatically with a local HTTP proxy server
+    And I start the system
+    When I send a "POST" request with proxy credentials to the local HTTP proxy server
+    Then I should receive request details without proxy credentials from the local HTTP proxy server
+
   @config
   Scenario Outline: The configured HTTP proxy returns a <kind> response
     Given I configure the system through configuration with servers

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -72,6 +72,10 @@ When('I send a {string} request with body {string} to the local HTTP proxy serve
   @response = http_client_for_server('local_http_proxy_server').inspect_request(verb.downcase, body)
 end
 
+When('I send a {string} request with proxy credentials to the local HTTP proxy server') do |verb|
+  @response = http_client_for_server('local_http_proxy_server').inspect_request_with_proxy_credentials(verb.downcase)
+end
+
 Then('I should receive an HTTP {string} response') do |response|
   @responses.each do |r|
     expect(r.code).to eq(200)
@@ -111,6 +115,15 @@ Then('I should receive the {string} request details from the local HTTP proxy se
   expect(@error).to be_nil
   expect(@response.code).to eq(200)
   expect(body).to match_inspected_proxy_request(verb, 'Hello World!')
+end
+
+Then('I should receive request details without proxy credentials from the local HTTP proxy server') do
+  body = JSON.parse(@response.body)
+
+  expect(@error).to be_nil
+  expect(@response.code).to eq(200)
+  expect(body['authorization']).to eq('Bearer app-token')
+  expect(body['proxy_authorization']).to be_nil
 end
 
 Then('I should find the server runner {string}') do |name|

--- a/features/support/http_client.rb
+++ b/features/support/http_client.rb
@@ -50,6 +50,28 @@ module Nonnative
         end
       end
 
+      def inspect_request_with_proxy_credentials(verb)
+        with_retry(1, 1) do
+          headers = {
+            authorization: 'Bearer app-token',
+            proxy_authorization: 'Basic proxy-secret',
+            content_type: :json,
+            accept: :json
+          }
+
+          with_exception do
+            RestClient::Request.execute(
+              method: verb.to_sym,
+              url: URI.join(host, 'inspect').to_s,
+              payload: 'Hello World!',
+              headers:,
+              read_timeout: 1,
+              open_timeout: 1
+            )
+          end
+        end
+      end
+
       def not_found
         with_retry(1, 1) do
           get('notfound', { headers: { content_type: :json, accept: :json }, read_timeout: 1, open_timeout: 1 })

--- a/features/support/http_server.rb
+++ b/features/support/http_server.rb
@@ -34,6 +34,7 @@ module Nonnative
             content_type: request.media_type,
             content_length: request.content_length,
             authorization: request.env['HTTP_AUTHORIZATION'],
+            proxy_authorization: request.env['HTTP_PROXY_AUTHORIZATION'],
             user_agent: request.env['HTTP_USER_AGENT']
           }
         end

--- a/lib/nonnative/http_proxy_server.rb
+++ b/lib/nonnative/http_proxy_server.rb
@@ -23,6 +23,14 @@ module Nonnative
   #
   # Supported HTTP verbs: GET, POST, PUT, PATCH, DELETE.
   class HTTPProxy < Sinatra::Application
+    NON_FORWARDABLE_HEADERS = %w[
+      Host
+      Accept-Encoding
+      Version
+      Proxy-Authenticate
+      Proxy-Authorization
+    ].freeze
+
     # Extracts request headers from the Rack environment and normalizes them to standard HTTP names.
     #
     # Certain hop-by-hop or proxy-specific headers are removed.
@@ -36,7 +44,7 @@ module Nonnative
         result[normalized_header_name(header)] = value
       end
 
-      headers.except('Host', 'Accept-Encoding', 'Version')
+      headers.except(*NON_FORWARDABLE_HEADERS)
     end
 
     # Builds the upstream URL for the given request.

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.2.1'
+  VERSION = '3.3.0'
 end


### PR DESCRIPTION
## What

- Filter proxy-only authorization headers before the local forward proxy sends requests upstream.
- Add Cucumber coverage proving regular application Authorization still reaches the upstream inspection endpoint while Proxy-Authorization is stripped.
- Bump the gem version to 3.3.0 in VERSION and Gemfile.lock.

## Why

- Prevent proxy credentials from leaking to upstream services when callers exercise dependencies through the in-process forward proxy.
- Preserve the existing request-forwarding behavior for application headers while tightening the proxy boundary.

## Testing

- `make lint` - passed
- `make sec` - passed
- `make features` - passed
- `make benchmarks` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
