### PR TITLE
feat(config): bound runner lifecycle checks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.3.0)
+    nonnative (3.4.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Common runner fields:
 
 Process/server fields:
 - `ports`: client-facing ports. These are also used for readiness/shutdown port checks.
-- `timeout`: max time (seconds) for readiness/shutdown port checks.
+- `timeout`: max time (seconds) for readiness/shutdown port checks. Defaults to `1.0`.
 - `wait`: small sleep (seconds) between lifecycle steps.
 - `log`: per-runner log file used by process output redirection or server implementations.
 

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -53,6 +53,16 @@ Feature: Configuration loading
     Given I load a temporary configuration with a top-level wait and a process
     Then the configured process "default_wait_process" should have wait 0.1
 
+  Scenario: Missing runner timeouts default to bounded lifecycle checks
+    Given I load a temporary configuration with omitted runner timeouts
+    Then the configured process "default_timeout_process" should have timeout 1.0
+    And the configured server "default_timeout_server" should have timeout 1.0
+
+  Scenario: YAML preserves explicit runner timeouts
+    Given I load a temporary configuration with explicit runner timeouts
+    Then the configured process "explicit_timeout_process" should have timeout 2.5
+    And the configured server "explicit_timeout_server" should have timeout 3.5
+
   Scenario: Missing hosts default to loopback
     Given I load a temporary configuration with omitted hosts
     Then the configured process "default_host_process" should use host "127.0.0.1"

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -108,6 +108,50 @@ Given('I load a temporary configuration with a top-level wait and a process') do
   YAML
 end
 
+Given('I load a temporary configuration with omitted runner timeouts') do
+  load_temporary_configuration(<<~YAML)
+    version: "1.0"
+    name: test
+    url: http://localhost:4567
+    log: test/reports/nonnative.log
+    processes:
+      - name: default_timeout_process
+        command: features/support/bin/start 12_398
+        ports:
+          - 12398
+        log: test/reports/12_398.log
+    servers:
+      - name: default_timeout_server
+        class: Nonnative::Features::TCPServer
+        ports:
+          - 12397
+        log: test/reports/default_timeout_server.log
+  YAML
+end
+
+Given('I load a temporary configuration with explicit runner timeouts') do
+  load_temporary_configuration(<<~YAML)
+    version: "1.0"
+    name: test
+    url: http://localhost:4567
+    log: test/reports/nonnative.log
+    processes:
+      - name: explicit_timeout_process
+        command: features/support/bin/start 12_396
+        timeout: 2.5
+        ports:
+          - 12396
+        log: test/reports/12_396.log
+    servers:
+      - name: explicit_timeout_server
+        class: Nonnative::Features::TCPServer
+        timeout: 3.5
+        ports:
+          - 12395
+        log: test/reports/explicit_timeout_server.log
+  YAML
+end
+
 Given('I load a temporary configuration containing ERB') do
   @erb_side_effect_path = "test/reports/#{SecureRandom.hex(4)}"
   load_temporary_configuration(<<~YAML)
@@ -305,6 +349,18 @@ Then('the configured process {string} should have wait {float}') do |name, wait|
   process = configured_process(name)
 
   expect(process.wait).to eq(wait)
+end
+
+Then('the configured process {string} should have timeout {float}') do |name, timeout|
+  process = configured_process(name)
+
+  expect(process.timeout).to eq(timeout)
+end
+
+Then('the configured server {string} should have timeout {float}') do |name, timeout|
+  server = configured_server(name)
+
+  expect(server.timeout).to eq(timeout)
 end
 
 Then('the configured process {string} should use host {string}') do |name, host|

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -191,7 +191,8 @@ module Nonnative
 
     def runner_attributes(runner, loaded)
       runner.name = loaded.name
-      runner.timeout = loaded.timeout
+      timeout = loaded.timeout
+      runner.timeout = timeout unless timeout.nil?
       runner.wait = loaded.wait if loaded.wait
       runner.host = loaded.host if loaded.host
       assign_ports(runner, loaded)

--- a/lib/nonnative/configuration_process.rb
+++ b/lib/nonnative/configuration_process.rb
@@ -19,7 +19,7 @@ module Nonnative
     # @return [String, nil] signal name to use for stopping (defaults to `"INT"` when not set)
     attr_accessor :signal
 
-    # @return [Numeric] readiness timeout (seconds) used when waiting for ports to open/close
+    # @return [Numeric] readiness timeout (seconds) used when waiting for ports to open/close (defaults to `1.0`)
     attr_accessor :timeout
 
     # @return [String] log file path to append process stdout/stderr to
@@ -27,5 +27,17 @@ module Nonnative
 
     # @return [Hash, nil] environment variables to pass to the spawned process
     attr_accessor :environment
+
+    # Creates a process configuration with bounded lifecycle defaults.
+    #
+    # Defaults:
+    # - `timeout`: `1.0`
+    #
+    # @return [void]
+    def initialize
+      super
+
+      self.timeout = DEFAULT_TIMEOUT
+    end
   end
 end

--- a/lib/nonnative/configuration_runner.rb
+++ b/lib/nonnative/configuration_runner.rb
@@ -12,6 +12,9 @@ module Nonnative
   # @see Nonnative::ConfigurationServer
   # @see Nonnative::ConfigurationService
   class ConfigurationRunner
+    # Default bounded readiness/shutdown timeout for process and server runners.
+    DEFAULT_TIMEOUT = 1.0
+
     # @return [String, nil] runner name used for lookup (for example via `pool.process_by_name`)
     attr_accessor :name
 

--- a/lib/nonnative/configuration_server.rb
+++ b/lib/nonnative/configuration_server.rb
@@ -14,10 +14,22 @@ module Nonnative
     # @return [Class] a class that implements `#initialize(service)` and the hooks expected by {Nonnative::Server}
     attr_accessor :klass
 
-    # @return [Numeric] readiness timeout (seconds) used when waiting for ports to open/close
+    # @return [Numeric] readiness timeout (seconds) used when waiting for ports to open/close (defaults to `1.0`)
     attr_accessor :timeout
 
     # @return [String] log file path used by server implementations (for example Puma/gRPC log files)
     attr_accessor :log
+
+    # Creates a server configuration with bounded lifecycle defaults.
+    #
+    # Defaults:
+    # - `timeout`: `1.0`
+    #
+    # @return [void]
+    def initialize
+      super
+
+      self.timeout = DEFAULT_TIMEOUT
+    end
   end
 end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.3.0'
+  VERSION = '3.4.0'
 end


### PR DESCRIPTION
## What

- Default process and server runner timeouts to `1.0` second for lifecycle TCP readiness and shutdown checks when callers omit `timeout`.
- Preserve explicit YAML timeout values while documenting the new default in README/RDoc.
- Bump the gem version to `3.4.0`.

## Why

- Omitting process or server timeouts could leave lifecycle port checks waiting indefinitely when a port never opened or closed.
- A bounded default keeps lifecycle behavior safe without changing caller-provided timeout values.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- Added Cucumber coverage for omitted runner timeouts and explicit YAML timeout preservation.
