### PR TITLE
feat(process): reap timed-out children

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.4.0)
+    nonnative (3.5.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/features/lifecycle.feature
+++ b/features/lifecycle.feature
@@ -19,6 +19,8 @@ Feature: Lifecycle
     Then stopping the system should raise an error containing:
       | Stopped no_exit_process with id       |
       | though the process did not exit in time |
+    And the process "no_exit_process" should no longer exist
+    And the port "12410" should be closed
 
   Scenario: Rollback errors are included in start failures
     Given I configure a pool that fails to start and raises on rollback
@@ -31,6 +33,8 @@ Feature: Lifecycle
     Then starting the system should raise an error containing:
       | Rollback failed for rollback_process with id |
       | because the process did not exit in time     |
+    And the process "rollback_process" should no longer exist
+    And the port "12411" should be closed
 
   Scenario: Process readiness requires every configured port to open
     Given I configure the system with a process that opens only one configured port

--- a/features/step_definitions/lifecycle_steps.rb
+++ b/features/step_definitions/lifecycle_steps.rb
@@ -178,6 +178,13 @@ Then('the process should no longer exist') do
   expect(@process_exists).to eq(false)
 end
 
+Then('the process {string} should no longer exist') do |name|
+  process = Nonnative.pool.process_by_name(name)
+  pid = process.instance_variable_get(:@pid)
+
+  wait_for { process_alive?(pid) }.to eq(false)
+end
+
 Then('the logger should be recreated for the new configuration') do
   expect(@second_logger).not_to equal(@first_logger)
   expect(File.read(@first_log_path)).to include('before clear')

--- a/features/support/context/lifecycle_support.rb
+++ b/features/support/context/lifecycle_support.rb
@@ -48,6 +48,13 @@ module Nonnative
           nil
         end
 
+        def process_alive?(pid)
+          ::Process.kill(0, pid)
+          true
+        rescue Errno::ESRCH
+          false
+        end
+
         def build_ordered_pool(events)
           build_pool(
             services: [Nonnative::Features::RecordingService.new(name: 'service_1', events:)],

--- a/lib/nonnative/process.rb
+++ b/lib/nonnative/process.rb
@@ -49,6 +49,7 @@ module Nonnative
       if process_exists?
         process_kill
         stopped = wait_stop != false
+        force_stop unless stopped
       end
 
       [pid, stopped]
@@ -80,6 +81,13 @@ module Nonnative
     def process_kill
       signal = Signal.list[service.signal || 'INT'] || Signal.list['INT']
       ::Process.kill(signal, pid)
+    end
+
+    def force_stop
+      ::Process.kill('KILL', pid)
+      wait_stop
+    rescue Errno::ESRCH, Errno::ECHILD
+      true
     end
 
     def process_spawn

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.4.0'
+  VERSION = '3.5.0'
 end


### PR DESCRIPTION
## What

- Force-clean and reap managed child processes when graceful stop or rollback times out.
- Keep the existing timeout error reporting so callers still know the graceful shutdown failed.
- Add lifecycle coverage that verifies timed-out children are gone and their ports are closed after stop and rollback.
- Bump the gem version to `3.5.0`.

## Why

- Managed children that ignore the configured stop signal could keep running after `Nonnative.stop` or startup rollback, leaving ports and background work stranded for later tests.
- The hard cleanup path makes teardown bounded while preserving the current caller-facing timeout signal.

## Testing

- `make features feature=features/lifecycle.feature` - passed
- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- `git diff --check` - passed
