### PR TITLE
feat(http): close puma log handles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.5.0)
+    nonnative (3.6.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/lib/nonnative/http_server.rb
+++ b/lib/nonnative/http_server.rb
@@ -39,7 +39,8 @@ module Nonnative
     # @param app [#call] a Rack-compatible application (e.g. Sinatra/Rack app)
     # @param service [Nonnative::ConfigurationServer] server configuration
     def initialize(app, service)
-      log = File.open(service.log, 'a')
+      # Keep the log IO so the server lifecycle can release Puma's file handle on stop.
+      @log = File.open(service.log, 'a')
       options = {
         log_writer: Puma::LogWriter.new(log, log),
         force_shutdown_after: service.timeout
@@ -66,10 +67,16 @@ module Nonnative
     # @return [void]
     def perform_stop
       server.graceful_shutdown
+    ensure
+      close_log
     end
 
     private
 
-    attr_reader :server
+    attr_reader :server, :log
+
+    def close_log
+      log.close unless log.closed?
+    end
   end
 end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.5.0'
+  VERSION = '3.6.0'
 end


### PR DESCRIPTION
## What

- Close Puma log file handles when HTTP server runners stop.
- Keep HTTP shutdown behavior on the existing lifecycle path while retaining the log IO for cleanup.
- Bump the gem version to 3.6.0.

## Why

- Repeated HTTP server runner lifecycles could leave log descriptors open after stop, increasing descriptor pressure in longer test suites.
- Tying the log handle to the server lifecycle releases the file descriptor once Puma shutdown completes.

## Testing

- `make features feature=features/servers.feature` - passed
- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- `git diff --check` - passed
- No new regression scenario was added per maintainer direction; existing server lifecycle coverage was rerun.
