### PR TITLE
feat(proxy): reject unknown kinds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.6.0)
+    nonnative (3.7.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ These proxies can simulate different situations. Available proxy kinds are:
 - `fault_injection`
 
 > [!WARNING]
-> Unknown proxy kinds fall back to `none`. If fault injection is not taking effect, check the `kind` spelling or register the custom kind before loading the configuration.
+> Unknown proxy kinds raise an error. If fault injection is not taking effect, check the `kind` spelling or register the custom kind before starting the system.
 
 Custom proxy kinds can be registered through `Nonnative.proxies`:
 

--- a/features/servers.feature
+++ b/features/servers.feature
@@ -70,3 +70,8 @@ Feature: Servers
   Scenario: Custom proxy kinds can be registered
     When I register a custom proxy kind
     Then the custom proxy kind should resolve to the custom proxy
+
+  @proxy @contract
+  Scenario: Unknown proxy kinds are rejected
+    When I try to resolve proxy kind "missing"
+    Then resolving the proxy kind should fail with an argument error containing "Unsupported proxy kind 'missing'"

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -52,12 +52,21 @@ When('I register a custom proxy kind') do
   Nonnative.proxies['custom'] = Nonnative::Features::CustomProxy
 end
 
+When('I try to resolve proxy kind {string}') do |kind|
+  capture_result(:@proxy_result, :@proxy_error) { Nonnative.proxy(kind) }
+end
+
 Then('the custom proxy kind should resolve to the custom proxy') do
   actual = Nonnative.proxy('custom')
   Nonnative.proxies.delete('custom')
   Nonnative.proxies['custom'] = @previous_custom_proxy if @previous_custom_proxy
 
   expect(actual).to eq(Nonnative::Features::CustomProxy)
+end
+
+Then('resolving the proxy kind should fail with an argument error containing {string}') do |message|
+  expect(@proxy_error).to be_a(ArgumentError)
+  expect(@proxy_error.message).to include(message)
 end
 
 When('I send a successful message to the HTTP proxy server') do

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -204,7 +204,7 @@ module Nonnative
     # @param kind [String] proxy kind name (for example `"fault_injection"`)
     # @return [Class] a subclass of {Nonnative::Proxy}
     def proxy(kind)
-      Nonnative.proxies[kind] || Nonnative::NoProxy
+      kind.nil? || kind == 'none' ? NoProxy : proxies.fetch(kind) { raise ArgumentError, "Unsupported proxy kind '#{kind}'" }
     end
 
     # Starts all configured services, servers, and processes, and waits for readiness.

--- a/lib/nonnative/no_proxy.rb
+++ b/lib/nonnative/no_proxy.rb
@@ -3,7 +3,7 @@
 module Nonnative
   # No-op proxy implementation.
   #
-  # This is the default proxy when `service.proxy.kind` is `"none"` (or an unknown kind is provided).
+  # This is the default proxy when `service.proxy.kind` is `"none"`.
   # It does not bind/listen or alter traffic; it simply exposes the underlying runner's configured
   # `host` and primary `port`.
   #

--- a/lib/nonnative/proxy_factory.rb
+++ b/lib/nonnative/proxy_factory.rb
@@ -6,7 +6,9 @@ module Nonnative
   # A runtime service constructs a proxy via this factory. The proxy implementation is selected by
   # `service.proxy.kind` and resolved using {Nonnative.proxy}.
   #
-  # If the kind is unknown (or `"none"`), {Nonnative.proxy} returns {Nonnative::NoProxy}.
+  # If the kind is `"none"`, {Nonnative.proxy} returns {Nonnative::NoProxy}.
+  # Unknown non-`"none"` kinds raise an error so proxy configuration typos do not silently disable
+  # fault injection.
   #
   # @see Nonnative.proxy
   # @see Nonnative.proxies

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.6.0'
+  VERSION = '3.7.0'
 end


### PR DESCRIPTION
## What

- Reject unknown non-`none` kinds instead of silently resolving them to the no-op implementation.
- Keep `none` and registered custom kinds working through the existing resolver.
- Update the README and bump the gem version to 3.7.0.

## Why

- A misspelled kind could previously disable fault injection without a clear failure, leaving resilience tests with false confidence.
- Failing fast makes configuration mistakes visible before the system starts.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- `make sec` - passed
