### PR TITLE
feat(diagnostics): show failed lifecycle endpoints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.7.0)
+    nonnative (3.8.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/features/lifecycle.feature
+++ b/features/lifecycle.feature
@@ -41,6 +41,8 @@ Feature: Lifecycle
     When I attempt to start the system
     Then starting the system should raise an error containing "Started partial_ports_process with id"
     And starting the system should raise an error containing "though did not respond in time"
+    And starting the system should raise an error containing "127.0.0.1:12415, 127.0.0.1:12416"
+    And starting the system should raise an error containing "log: test/reports/12_415.log"
 
   Scenario: Pool starts services before servers and processes
     When I start a pool with ordered services, servers, and processes

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -216,9 +216,9 @@ module Nonnative
     def start
       @pool ||= Nonnative::Pool.new(configuration)
       errors = []
-      errors.concat(@pool.start do |name, values, result|
+      errors.concat(@pool.start do |name, values, result, ports|
         id, started = values
-        errors << "Started #{name} with id #{id}, though did not respond in time" if !started || !result
+        errors << "Started #{name} with id #{id}, though did not respond in time for #{ports.description}" if !started || !result
       end)
       nil
     rescue StandardError => e
@@ -239,9 +239,9 @@ module Nonnative
       errors = []
       return if @pool.nil?
 
-      errors.concat(@pool.stop do |name, values, result|
+      errors.concat(@pool.stop do |name, values, result, ports|
         id, stopped = Array(values).then { |v| [v.first, v.fetch(1, true)] }
-        errors << "Stopped #{name} with id #{id}, though did not respond in time" unless result
+        errors << "Stopped #{name} with id #{id}, though did not respond in time for #{ports.description}" unless result
         errors << "Stopped #{name} with id #{id}, though the process did not exit in time" unless stopped
       end)
       nil
@@ -305,9 +305,9 @@ module Nonnative
       errors = []
       return errors if @pool.nil?
 
-      errors.concat(@pool.rollback do |name, values, result|
+      errors.concat(@pool.rollback do |name, values, result, ports|
         id, stopped = Array(values).then { |v| [v.first, v.fetch(1, true)] }
-        errors << "Rollback failed for #{name} with id #{id}, because it did not stop in time" unless result
+        errors << "Rollback failed for #{name} with id #{id}, because it did not stop in time for #{ports.description}" unless result
         errors << "Rollback failed for #{name} with id #{id}, because the process did not exit in time" unless stopped
       end)
     rescue StandardError => e

--- a/lib/nonnative/pool.rb
+++ b/lib/nonnative/pool.rb
@@ -30,6 +30,7 @@ module Nonnative
     # @yieldparam name [String, nil] runner name
     # @yieldparam values [Object] runner-specific return value from `start` (e.g. `[pid, running]` for processes)
     # @yieldparam result [Boolean] result of the port readiness check (`true` if ready in time)
+    # @yieldparam port [Nonnative::Ports] checked port group
     # @return [Array<String>] lifecycle and readiness-check errors collected while starting
     def start(&)
       errors = []
@@ -47,6 +48,7 @@ module Nonnative
     # @yieldparam name [String, nil] runner name
     # @yieldparam id [Object] runner-specific identifier returned by `stop` (e.g. pid or object_id)
     # @yieldparam result [Boolean] result of the port shutdown check (`true` if closed in time)
+    # @yieldparam port [Nonnative::Ports] checked port group
     # @return [Array<String>] lifecycle and shutdown-check errors collected while stopping
     def stop(&)
       errors = []
@@ -65,6 +67,7 @@ module Nonnative
     # @yieldparam name [String, nil] runner name
     # @yieldparam id [Object] runner-specific identifier returned by `stop`
     # @yieldparam result [Boolean] result of the port shutdown check (`true` if closed in time)
+    # @yieldparam port [Nonnative::Ports] checked port group
     # @return [Array<String>] lifecycle and shutdown-check errors collected while rolling back
     def rollback(&)
       errors = []
@@ -183,7 +186,7 @@ module Nonnative
 
       runners.each do |runner, port|
         values = runner.send(lifecycle_method)
-        checks << [runner, values, Thread.new { check_port(port, port_method) }]
+        checks << [runner, values, port, Thread.new { check_port(port, port_method) }]
       rescue StandardError => e
         errors << lifecycle_error(action, runner, e)
       end
@@ -198,12 +201,12 @@ module Nonnative
     end
 
     def yield_results(checks, action, &)
-      checks.each_with_object([]) do |(type, values, thread), errors|
+      checks.each_with_object([]) do |(type, values, port, thread), errors|
         result = thread.value
         if result[:error]
           errors << port_error(action, type, result[:error])
         elsif block_given?
-          yield type.name, values, result[:result]
+          yield type.name, values, result[:result], port
         end
       end
     end

--- a/lib/nonnative/port.rb
+++ b/lib/nonnative/port.rb
@@ -61,6 +61,13 @@ module Nonnative
       end
     end
 
+    # Returns a human-readable endpoint for lifecycle diagnostics.
+    #
+    # @return [String]
+    def endpoint
+      "#{process.host}:#{port}"
+    end
+
     private
 
     attr_reader :process, :port, :timeout

--- a/lib/nonnative/ports.rb
+++ b/lib/nonnative/ports.rb
@@ -10,6 +10,7 @@ module Nonnative
   class Ports
     # @param runner [#host, #ports, #timeout] runner configuration providing connection details
     def initialize(runner)
+      @runner = runner
       @ports = runner.ports.map { |port| Nonnative::Port.new(runner, port) }
     end
 
@@ -27,8 +28,23 @@ module Nonnative
       ports.all?(&:closed?)
     end
 
+    # Returns the checked endpoints for lifecycle diagnostics.
+    #
+    # @return [String]
+    def endpoints
+      ports.map(&:endpoint).join(', ')
+    end
+
+    # Returns endpoint and log context for lifecycle errors.
+    #
+    # @return [String]
+    def description
+      log = runner.log if runner.respond_to?(:log)
+      log ? "#{endpoints} (log: #{log})" : endpoints
+    end
+
     private
 
-    attr_reader :ports
+    attr_reader :ports, :runner
   end
 end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.7.0'
+  VERSION = '3.8.0'
 end


### PR DESCRIPTION
## What

- Include lifecycle endpoint details in startup, shutdown, and rollback timeout errors.
- Include the configured runner log path in those timeout errors when available.
- Bump the gem version to 3.8.0.

## Why

- Lifecycle timeout failures previously identified the runner but not the endpoint or log file to inspect.
- The extra context makes failed starts and stops faster to triage while keeping the existing timeout wording intact.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- `make sec` - passed
