### PR TITLE
feat(process): gate startup on http readiness

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.8.0)
+    nonnative (3.9.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -66,13 +66,16 @@ Process/server fields:
 - `wait`: small sleep (seconds) between lifecycle steps.
 - `log`: per-runner log file used by process output redirection or server implementations.
 
+Process-only fields:
+- `readiness`: optional HTTP startup readiness check with explicit `port` and `path`.
+
 Service fields:
 - `port`: client-facing service port. Services do not get TCP readiness/shutdown checks from Nonnative.
 
-Nonnative readiness and shutdown checks are TCP-only. Configure process/server ports that are dedicated to the test run; if another process is already listening on the same endpoint, results are undefined.
+Nonnative readiness and shutdown checks are TCP port checks by default. Configure process/server ports that are dedicated to the test run; if another process is already listening on the same endpoint, results are undefined. Processes can also opt into an HTTP readiness check that runs after TCP readiness succeeds.
 
 > [!WARNING]
-> Readiness and shutdown checks only prove that a TCP port opened or closed. They do not verify HTTP status, gRPC health, schema readiness, migrations, or application-specific health.
+> TCP readiness and shutdown checks only prove that a TCP port opened or closed. HTTP readiness is process-only, checks for a 2xx response, and does not verify gRPC health, schema readiness, migrations, or other application-specific health.
 
 Start and stop Nonnative around the test scope that should own the configured runners:
 
@@ -170,6 +173,7 @@ Nonnative.configure do |config|
     p.ports = [12_321]
     p.log = '12_321.log'
     p.signal = 'INT' # Possible values are described in Signal.list.keys.
+    p.readiness = { port: 12_321, path: '/test/readyz' }
     p.environment = { # Pass environment variables to process.
       'TEST' => 'true'
     }
@@ -205,6 +209,9 @@ processes:
       - 12321
     log: 12_321.log
     signal: INT # Possible values are described in Signal.list.keys.
+    readiness:
+      port: 12321
+      path: /test/readyz
     environment: # Pass environment variables to process.
       TEST: true
   -

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -17,6 +17,19 @@ Feature: Configuration loading
       | 12420 |
       | 12421 |
 
+  Scenario: YAML maps process HTTP readiness
+    Given I load a temporary configuration with process HTTP readiness
+    Then the configured process "ready_process" readiness should use port 12427 and path "/test/readyz"
+
+  Scenario Outline: YAML rejects incomplete process HTTP readiness
+    When I attempt to load a temporary configuration with process HTTP readiness missing "<field>"
+    Then loading the configuration should fail with an argument error containing "Process readiness requires '<field>'"
+
+    Examples:
+      | field |
+      | port  |
+      | path  |
+
   Scenario: YAML rejects singular process ports
     When I attempt to load a temporary configuration with a singular runner port
     Then loading the configuration should fail with an argument error containing "Use 'ports' instead of 'port'"
@@ -44,6 +57,14 @@ Feature: Configuration loading
   Scenario: YAML rejects server proxies
     When I attempt to load a temporary configuration with a server proxy
     Then loading the configuration should fail with an argument error containing "servers do not support 'proxy'"
+
+  Scenario: YAML rejects server readiness
+    When I attempt to load a temporary configuration with server readiness
+    Then loading the configuration should fail with an argument error containing "servers do not support 'readiness'"
+
+  Scenario: YAML rejects service readiness
+    When I attempt to load a temporary configuration with service readiness
+    Then loading the configuration should fail with an argument error containing "services do not support 'readiness'"
 
   Scenario: Server YAML class entries resolve to server implementations
     Given I load a temporary configuration with a server entry

--- a/features/processes.feature
+++ b/features/processes.feature
@@ -47,6 +47,17 @@ Feature: Process runners
     Then stopping the system should not raise an error
     And the port "12414" should be closed
 
+  Scenario: Process HTTP readiness gates startup
+    Given I configure the system programmatically with a process HTTP readiness check
+    And I start the system
+    When I send "test" with the TCP client "http_ready_process" to the process
+    Then I should receive a TCP "test" response from the process
+
+  Scenario: Process HTTP readiness failures are reported during startup
+    Given I configure the system programmatically with a failing process HTTP readiness check
+    When I attempt to start the system
+    Then starting the system should raise an error containing "readiness: http://127.0.0.1:12427/test/readyz"
+
   Scenario: Explicit process environment overrides the parent environment
     Given the parent environment variable "STRING" is "parent"
     When I start a process runner with environment "STRING" set to "configured"

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -54,6 +54,26 @@ Given('I load a temporary configuration with multiple runner ports') do
   YAML
 end
 
+Given('I load a temporary configuration with process HTTP readiness') do
+  load_temporary_configuration(<<~YAML)
+    version: "1.0"
+    name: test
+    url: http://localhost:4567
+    log: test/reports/nonnative.log
+    processes:
+      - name: ready_process
+        command: features/support/bin/start 12_426
+        timeout: 1
+        host: 127.0.0.1
+        ports:
+          - 12426
+        log: test/reports/12_426.log
+        readiness:
+          port: 12427
+          path: /test/readyz
+  YAML
+end
+
 Given('I load a temporary configuration with proxy options') do
   load_temporary_configuration(<<~YAML)
     version: "1.0"
@@ -179,7 +199,6 @@ Given('I load a temporary configuration with omitted hosts') do
 end
 
 When('I attempt to load a temporary configuration with a process proxy') do
-  @configuration_error = nil
   capture_result(:@configuration_result, :@configuration_error) do
     load_temporary_configuration(<<~YAML)
       version: "1.0"
@@ -202,7 +221,6 @@ When('I attempt to load a temporary configuration with a process proxy') do
 end
 
 When('I attempt to load a temporary configuration with a server proxy') do
-  @configuration_error = nil
   capture_result(:@configuration_result, :@configuration_error) do
     load_temporary_configuration(<<~YAML)
       version: "1.0"
@@ -224,8 +242,68 @@ When('I attempt to load a temporary configuration with a server proxy') do
   end
 end
 
+When('I attempt to load a temporary configuration with server readiness') do
+  capture_result(:@configuration_result, :@configuration_error) do
+    load_temporary_configuration(<<~YAML)
+      version: "1.0"
+      name: test
+      url: http://localhost:4567
+      log: test/reports/nonnative.log
+      servers:
+        - name: server_readiness
+          class: Nonnative::Features::TCPServer
+          ports:
+            - 12426
+          log: test/reports/server_readiness.log
+          readiness:
+            port: 12427
+            path: /test/readyz
+    YAML
+  end
+end
+
+When('I attempt to load a temporary configuration with service readiness') do
+  capture_result(:@configuration_result, :@configuration_error) do
+    load_temporary_configuration(<<~YAML)
+      version: "1.0"
+      name: test
+      url: http://localhost:4567
+      log: test/reports/nonnative.log
+      services:
+        - name: service_readiness
+          port: 12426
+          readiness:
+            port: 12427
+            path: /test/readyz
+    YAML
+  end
+end
+
+When('I attempt to load a temporary configuration with process HTTP readiness missing {string}') do |field|
+  readiness = { 'port' => 12_427, 'path' => '/test/readyz' }
+  readiness.delete(field)
+  readiness_yaml = readiness.map { |key, value| "#{key}: #{value}" }.join("\n")
+
+  capture_result(:@configuration_result, :@configuration_error) do
+    load_temporary_configuration(<<~YAML)
+      version: "1.0"
+      name: test
+      url: http://localhost:4567
+      log: test/reports/nonnative.log
+      processes:
+        - name: incomplete_ready_process
+          command: features/support/bin/start 12_426
+          timeout: 1
+          ports:
+            - 12426
+          log: test/reports/12_426.log
+          readiness:
+            #{readiness_yaml}
+    YAML
+  end
+end
+
 When('I attempt to load a temporary configuration with a Ruby object tag') do
-  @configuration_error = nil
   capture_result(:@configuration_result, :@configuration_error) do
     load_temporary_configuration(<<~YAML)
       --- !ruby/object:Object
@@ -236,7 +314,6 @@ When('I attempt to load a temporary configuration with a Ruby object tag') do
 end
 
 When('I attempt to load a temporary configuration with a singular runner port') do
-  @configuration_error = nil
   capture_result(:@configuration_result, :@configuration_error) do
     load_temporary_configuration(<<~YAML)
       version: "1.0"
@@ -254,7 +331,6 @@ When('I attempt to load a temporary configuration with a singular runner port') 
 end
 
 When('I attempt to load a temporary configuration with plural service ports') do
-  @configuration_error = nil
   capture_result(:@configuration_result, :@configuration_error) do
     load_temporary_configuration(<<~YAML)
       version: "1.0"
@@ -276,7 +352,6 @@ When('I attempt to load a temporary configuration with plural service ports') do
 end
 
 When('I attempt to configure a service with plural ports') do
-  @configuration_error = nil
   capture_result(:@configuration_result, :@configuration_error) do
     Nonnative.configure do |config|
       config.service do |service|
@@ -288,7 +363,6 @@ When('I attempt to configure a service with plural ports') do
 end
 
 When('I attempt to read plural ports from a configured service') do
-  @configuration_error = nil
   Nonnative.configure do |config|
     config.service do |service|
       service.name = 'legacy_ports_service'
@@ -302,7 +376,6 @@ When('I attempt to read plural ports from a configured service') do
 end
 
 When('I attempt to load a temporary configuration with {string} YAML') do |kind|
-  @configuration_error = nil
   capture_result(:@configuration_result, :@configuration_error) do
     load_temporary_configuration(malformed_yaml(kind))
   end
@@ -324,6 +397,13 @@ Then('the configured process {string} should use ports:') do |name, table|
   process = configured_process(name)
 
   expect(process.ports).to eq(table.raw.flatten.map(&:to_i))
+end
+
+Then('the configured process {string} readiness should use port {int} and path {string}') do |name, port, path|
+  process = configured_process(name)
+
+  expect(process.readiness.port).to eq(port)
+  expect(process.readiness.path).to eq(path)
 end
 
 Then('the configured service {string} proxy should use host {string} and port {int}') do |name, host, port|

--- a/features/step_definitions/processes_steps.rb
+++ b/features/step_definitions/processes_steps.rb
@@ -68,6 +68,14 @@ Given('I configure the system programmatically with a process that has no stop s
   end
 end
 
+Given('I configure the system programmatically with a process HTTP readiness check') do
+  configure_http_readiness_process(status: 200)
+end
+
+Given('I configure the system programmatically with a failing process HTTP readiness check') do
+  configure_http_readiness_process(status: 503)
+end
+
 Given('the parent environment variable {string} is {string}') do |name, value|
   @previous_environment ||= {}
   @previous_environment[name] = ENV.fetch(name, nil)

--- a/features/step_definitions/services_steps.rb
+++ b/features/step_definitions/services_steps.rb
@@ -31,7 +31,6 @@ end
 When('I stop the service runner {string} while clients connect') do |name|
   service = configured_service(name)
   runner = Nonnative.pool.service_by_name(name)
-  @stop_error = nil
 
   20.times do |iteration|
     runner.start if iteration.positive?

--- a/features/support/bin/http_readiness
+++ b/features/support/bin/http_readiness
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'socket'
+
+tcp_port = ARGV.fetch(0).to_i
+http_port = ARGV.fetch(1).to_i
+readiness_status = ARGV.fetch(2).to_i
+closing = false
+
+Signal.trap 'INT' do
+  closing = true
+end
+
+Signal.trap 'TERM' do
+  closing = true
+end
+
+tcp_server = TCPServer.new('0.0.0.0', tcp_port)
+http_server = TCPServer.new('0.0.0.0', http_port)
+
+Thread.new do
+  loop do
+    [tcp_server, http_server].each { |server| server.close if closing && !server.closed? }
+    exit if closing
+
+    sleep 0.01
+  rescue IOError
+    exit
+  end
+end
+
+Thread.new do
+  loop do
+    socket = tcp_server.accept
+    Thread.new(socket) do |conn|
+      loop do
+        line = conn.readline.strip
+        conn.puts(line)
+      end
+    rescue EOFError
+      conn.close
+    end
+  end
+rescue IOError, Errno::EBADF
+  nil
+end
+
+Thread.new do
+  loop do
+    socket = http_server.accept
+    Thread.new(socket) do |conn|
+      request = conn.gets.to_s
+      loop do
+        line = conn.gets
+        break if line.nil? || line == "\r\n"
+      end
+
+      status = request.include?('/test/readyz') ? readiness_status : 404
+      body = status == 200 ? 'ready' : 'not ready'
+      conn.write "HTTP/1.1 #{status}\r\n"
+      conn.write "Content-Length: #{body.bytesize}\r\n"
+      conn.write "Connection: close\r\n"
+      conn.write "\r\n"
+      conn.write body
+    ensure
+      conn.close
+    end
+  end
+rescue IOError, Errno::EBADF
+  nil
+end
+
+sleep

--- a/features/support/context/process_configuration.rb
+++ b/features/support/context/process_configuration.rb
@@ -31,7 +31,27 @@ module Nonnative
           end
         end
 
+        def configure_http_readiness_process(status:)
+          configure_with_defaults do |config|
+            add_process(config, http_readiness_process(status))
+          end
+        end
+
         private
+
+        def http_readiness_process(status)
+          {
+            name: 'http_ready_process',
+            command: -> { [RbConfig.ruby, 'features/support/bin/http_readiness', '12426', '12427', status.to_s] },
+            timeout: 2,
+            wait: 0.1,
+            host: '127.0.0.1',
+            ports: [12_426],
+            log: 'test/reports/12_426.log',
+            signal: 'INT',
+            readiness: { port: 12_427, path: '/test/readyz' }
+          }
+        end
 
         def add_process(config, definition)
           config.process do |process|
@@ -40,7 +60,7 @@ module Nonnative
         end
 
         def apply_process_definition(process, definition)
-          %i[name command timeout wait host ports log signal environment].each do |attribute|
+          %i[name command timeout wait host ports log signal environment readiness].each do |attribute|
             assign_process_attribute(process, definition, attribute)
           end
         end

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -6,7 +6,7 @@
 # It can:
 #
 # - start external processes and in-process servers
-# - wait for readiness via port checks
+# - wait for readiness via port checks and optional process HTTP readiness
 # - optionally run fault-injection proxies in front of services
 #
 # The public entry points are exposed as module-level methods on {Nonnative}.
@@ -27,6 +27,7 @@
 #       p.ports = [8080, 9090]
 #       p.timeout = 10
 #       p.log = 'api.log'
+#       p.readiness = { port: 8080, path: '/example/readyz' }
 #     end
 #   end
 #
@@ -72,6 +73,7 @@ require 'nonnative/ports'
 require 'nonnative/configuration_file'
 require 'nonnative/configuration'
 require 'nonnative/configuration_runner'
+require 'nonnative/configuration_readiness'
 require 'nonnative/configuration_process'
 require 'nonnative/configuration_server'
 require 'nonnative/configuration_service'
@@ -82,6 +84,7 @@ require 'nonnative/server'
 require 'nonnative/service'
 require 'nonnative/pool'
 require 'nonnative/http_client'
+require 'nonnative/http_probe'
 require 'nonnative/http_server'
 require 'nonnative/http_proxy_server'
 require 'nonnative/grpc_server'

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -22,6 +22,7 @@ module Nonnative
   #       p.ports = [8080, 9090]
   #       p.timeout = 10
   #       p.log = 'api.log'
+  #       p.readiness = { port: 8080, path: '/example/readyz' }
   #     end
   #   end
   #
@@ -142,6 +143,7 @@ module Nonnative
           process_config.command = command(loaded_process)
           process_config.signal = loaded_process.signal
           process_config.environment = loaded_process.environment
+          process_config.readiness = loaded_process.readiness if loaded_process.readiness
           runner_attributes(process_config, loaded_process)
         end
       end
@@ -163,6 +165,7 @@ module Nonnative
       servers = cfg.servers || []
       servers.each do |loaded_server|
         reject_proxy(loaded_server, 'servers')
+        reject_readiness(loaded_server, 'servers')
 
         server do |server_config|
           server_config.klass = Object.const_get(server_class_name(loaded_server))
@@ -174,6 +177,8 @@ module Nonnative
     def add_services(cfg)
       services = cfg.services || []
       services.each do |loaded_service|
+        reject_readiness(loaded_service, 'services')
+
         service do |service_config|
           service_config.name = loaded_service.name
           service_config.host = loaded_service.host if loaded_service.host
@@ -218,6 +223,13 @@ module Nonnative
       return unless values.key?(:proxy) || values.key?('proxy')
 
       raise ArgumentError, "Use 'services' for proxy configuration; #{kind} do not support 'proxy'"
+    end
+
+    def reject_readiness(loaded, kind)
+      values = loaded.to_h
+      return unless values.key?(:readiness) || values.key?('readiness')
+
+      raise ArgumentError, "Use 'processes' for readiness configuration; #{kind} do not support 'readiness'"
     end
 
     def assign_proxy(service, loaded_proxy)

--- a/lib/nonnative/configuration_process.rb
+++ b/lib/nonnative/configuration_process.rb
@@ -28,6 +28,9 @@ module Nonnative
     # @return [Hash, nil] environment variables to pass to the spawned process
     attr_accessor :environment
 
+    # @return [Nonnative::ConfigurationReadiness, nil] optional HTTP readiness check
+    attr_reader :readiness
+
     # Creates a process configuration with bounded lifecycle defaults.
     #
     # Defaults:
@@ -38,6 +41,14 @@ module Nonnative
       super
 
       self.timeout = DEFAULT_TIMEOUT
+    end
+
+    # Sets optional HTTP readiness configuration.
+    #
+    # @param value [Hash, #to_h, nil] readiness attributes with required `port` and `path`
+    # @return [void]
+    def readiness=(value)
+      @readiness = value.nil? ? nil : Nonnative::ConfigurationReadiness.new(value)
     end
   end
 end

--- a/lib/nonnative/configuration_readiness.rb
+++ b/lib/nonnative/configuration_readiness.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Nonnative
+  # HTTP readiness configuration for a managed process.
+  #
+  # Readiness is optional. When present, both `port` and `path` are required so the startup
+  # check has an explicit application endpoint to poll after TCP readiness succeeds.
+  class ConfigurationReadiness
+    # @return [Integer] process HTTP readiness port
+    attr_accessor :port
+
+    # @return [String] HTTP readiness path
+    attr_accessor :path
+
+    # @param value [Hash, #to_h] readiness attributes
+    def initialize(value)
+      attributes = value.respond_to?(:to_h) ? value.to_h : value
+      self.port = attribute(attributes, :port)
+      self.path = attribute(attributes, :path)
+
+      validate!
+    end
+
+    private
+
+    def attribute(attributes, name)
+      attributes[name] || attributes[name.to_s]
+    end
+
+    def validate!
+      raise ArgumentError, "Process readiness requires 'port'" if port.nil?
+      raise ArgumentError, "Process readiness requires 'path'" if path.nil?
+    end
+  end
+end

--- a/lib/nonnative/http_probe.rb
+++ b/lib/nonnative/http_probe.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Nonnative
+  # Probes a managed process HTTP readiness endpoint.
+  class HTTPProbe < Nonnative::HTTPClient
+    NETWORK_ERRORS = [
+      Errno::ECONNREFUSED,
+      Errno::EHOSTUNREACH,
+      Errno::ECONNRESET,
+      SocketError,
+      RestClient::Exceptions::Timeout,
+      RestClient::ServerBrokeConnection
+    ].freeze
+
+    # @param process [Nonnative::ConfigurationProcess] process configuration with readiness attributes
+    def initialize(process)
+      @readiness = process.readiness
+      @base_url = "http://#{process.host}:#{readiness.port}"
+      @timeout = Nonnative::Timeout.new(process.timeout)
+
+      super(base_url)
+    end
+
+    # Returns whether the configured HTTP endpoint returns a 2xx response before timeout.
+    #
+    # @return [Boolean]
+    def ready?
+      Nonnative.logger.info "checking if readiness '#{endpoint}' is ready"
+
+      timeout.perform do
+        response = get(readiness.path)
+        raise Nonnative::Error unless ready_response?(response)
+
+        true
+      rescue Nonnative::Error, *NETWORK_ERRORS
+        sleep_interval
+        retry
+      end
+    end
+
+    # Returns the HTTP readiness endpoint for lifecycle diagnostics.
+    #
+    # @return [String]
+    def endpoint
+      "#{base_url}#{path}"
+    end
+
+    private
+
+    attr_reader :base_url, :readiness, :timeout
+
+    def path
+      readiness.path.start_with?('/') ? readiness.path : "/#{readiness.path}"
+    end
+
+    def ready_response?(response)
+      response.respond_to?(:code) && response.code.to_i.between?(200, 299)
+    end
+
+    def sleep_interval
+      sleep 0.01
+    end
+  end
+end

--- a/lib/nonnative/ports.rb
+++ b/lib/nonnative/ports.rb
@@ -12,13 +12,14 @@ module Nonnative
     def initialize(runner)
       @runner = runner
       @ports = runner.ports.map { |port| Nonnative::Port.new(runner, port) }
+      @readiness = Nonnative::HTTPProbe.new(runner) if runner.respond_to?(:readiness) && runner.readiness
     end
 
     # Returns whether all configured ports become connectable before their timeouts elapse.
     #
     # @return [Boolean]
     def open?
-      ports.all?(&:open?)
+      ports.all?(&:open?) && (readiness.nil? || readiness.ready?)
     end
 
     # Returns whether all configured ports become non-connectable before their timeouts elapse.
@@ -39,12 +40,16 @@ module Nonnative
     #
     # @return [String]
     def description
+      details = []
+      details << "readiness: #{readiness.endpoint}" if readiness
       log = runner.log if runner.respond_to?(:log)
-      log ? "#{endpoints} (log: #{log})" : endpoints
+      details << "log: #{log}" if log
+
+      details.empty? ? endpoints : "#{endpoints} (#{details.join('; ')})"
     end
 
     private
 
-    attr_reader :ports, :runner
+    attr_reader :ports, :readiness, :runner
   end
 end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.8.0'
+  VERSION = '3.9.0'
 end


### PR DESCRIPTION
## What

- Add optional HTTP readiness checks for managed processes using explicit `readiness.port` and `readiness.path` config.
- Keep readiness unsupported for servers and services, and reject those YAML placements clearly.
- Include the labeled HTTP readiness endpoint in startup timeout diagnostics.
- Document the process-only readiness config and bump the gem version to 3.9.0.

## Why

- Managed processes can open a TCP port before their application readiness endpoint is actually ready.
- Waiting on the process-owned HTTP readiness signal reduces false-ready startups without probing external services or in-process test servers.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- `make sec` - passed
