### PR TITLE
docs(readme): clarify lifecycle reuse contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,11 @@ of dependencies.
   use `nonnative` against real dependencies. Do not flag the in-repository
   service proxy success scenario's connection-only assertion as a test gap
   unless the task is explicitly about changing service proxy forwarding.
+- `Nonnative::FaultInjectionProxy` owns its listener thread and stops it by
+  closing the owned `TCPServer`, which wakes the accept loop before joining the
+  thread. Do not flag the listener `join` as an unbounded reliability gap unless
+  the task is explicitly about proxy shutdown behavior or there is a normal-use
+  reproducer, failing CI evidence, or platform-specific hang evidence.
 
 ## Runtime Model
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Nonnative.stop
 `Nonnative.start` starts services first, then servers and processes. `Nonnative.stop` stops processes and servers first, then services. If startup fails, Nonnative rolls back runners that already started and raises `Nonnative::StartError`; shutdown failures raise `Nonnative::StopError`.
 
 > [!NOTE]
-> `Nonnative.clear` clears memoized configuration, logger, observability client, and pool. Use it before reconfiguring Nonnative in the same Ruby process.
+> `Nonnative.start` / `Nonnative.stop` manage one lifecycle for the current pool.
+> Call `Nonnative.clear` before reconfiguring Nonnative or starting a new lifecycle in the same Ruby process.
+> `Nonnative.clear` clears memoized configuration, logger, observability client, and pool.
 
 ### 📈 Observability
 

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -286,6 +286,9 @@ module Nonnative
 
     # Clears memoized configuration, logger, observability client, and pool.
     #
+    # Call this before reconfiguring Nonnative or starting a new lifecycle in the same Ruby process.
+    # `start`/`stop` are intended to manage one lifecycle for the current pool.
+    #
     # @return [void]
     def clear
       clear_logger


### PR DESCRIPTION
## What

- Clarify that `Nonnative.start` / `Nonnative.stop` manage one lifecycle for the current pool.
- Document that callers should use `Nonnative.clear` before reconfiguring or starting a new lifecycle in the same Ruby process.
- Record the intentional `FaultInjectionProxy` listener shutdown pattern in repository agent guidance so future reliability reviews require normal-use evidence before flagging it.

## Why

- The lifecycle API keeps pool state memoized, so users need an explicit contract for when `clear` is required.
- The proxy listener concern was checked under normal use and did not reproduce, so repository guidance now prevents rediscovering it as a confirmed gap without stronger evidence.

## Testing

- `make lint` - passed
- Proxy shutdown reproduction checks - passed before recording the AGENTS guidance: 100 real proxy stop-under-load iterations and 1000 `TCPServer#accept` close/join iterations completed without hangs.
- No feature suite run for this final documentation-only change.
