### PR TITLE
feat(process): refresh memory reader on restart

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.9.0)
+    nonnative (3.10.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/lib/nonnative/process.rb
+++ b/lib/nonnative/process.rb
@@ -20,6 +20,9 @@ module Nonnative
       @timeout = Nonnative::Timeout.new(service.timeout)
     end
 
+    # @return [GetProcessMem, nil] memory reader for the current process lifecycle
+    attr_reader :memory
+
     # Spawns the configured process if it is not already running.
     #
     # @return [Array<(Integer, Boolean)>]
@@ -29,6 +32,8 @@ module Nonnative
     def start
       unless process_exists?
         @pid = process_spawn
+        # Keep memory reads bound to the child spawned for this lifecycle.
+        @memory = GetProcessMem.new(pid)
         wait_start
       end
 
@@ -53,17 +58,8 @@ module Nonnative
       end
 
       [pid, stopped]
-    end
-
-    # Returns a memoized memory reader for the spawned process.
-    #
-    # This is primarily used by acceptance tests to assert memory usage.
-    #
-    # @return [GetProcessMem, nil] a memory reader for the pid, or `nil` if not started
-    def memory
-      return if pid.nil?
-
-      @memory ||= GetProcessMem.new(pid)
+    ensure
+      @memory = nil
     end
 
     protected

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.9.0'
+  VERSION = '3.10.0'
 end


### PR DESCRIPTION
## What

- Bind memory usage reads to the currently managed child lifecycle, recreating the reader after a restart and clearing it after stop.
- Bump the gem version and lockfile entry to 3.10.0.
- Keep the public Cucumber memory assertion unchanged.

## Why

- Downstream benchmark suites can run multiple `@startup` scenarios in one Ruby process, which restarts a configured runner under a new PID.
- The previous memoized memory reader could keep pointing at the stopped PID and fail the next memory assertion with `Errno::ESRCH`.

## Testing

- `make dep` - passed
- `make lint` - passed
- `make sec` - passed
- `make features` - passed
- `make benchmarks` - passed
- `RUBYLIB=/Users/alejandro/code/nonnative/lib make benchmarks` in `/Users/alejandro/code/migrieren` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
