### PR TITLE
docs(readme): clarify contributor setup and public lifecycle contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Or install it yourself as:
 gem install nonnative
 ```
 
+## 🛠️ Contributor Bootstrap
+
+Fresh clones need the shared `bin/` submodule before Make targets can load:
+
+```bash
+git submodule sync && git submodule update --init
+make help
+```
+
+Use `make dep` before local validation when dependencies are missing. The CI-parity checks are
+`make lint`, `make sec`, `make features`, and `make benchmarks`.
+
 ## 🚀 Usage
 
 Nonnative is configured via `Nonnative.configure` (programmatic) or `config.load_file(...)` (YAML).
@@ -154,7 +166,7 @@ expect(response.code).to eq(200)
 
 Nonnative ships Cucumber hooks (when loaded) that support these tags/strategies:
 - `@startup`: start before scenario; stop after scenario
-- `@manual`: stop after scenario (start is expected to be triggered manually in steps)
+- `@manual`: stop after scenario; use `When I start the system` to start manually
 - `@clear`: clears memoized configuration, logger, observability client, and pool before scenario
 - `@reset`: resets proxies after scenario
 

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -204,8 +204,12 @@ module Nonnative
 
     # Resolves a proxy implementation for a configured kind.
     #
+    # `nil` and `"none"` resolve to {Nonnative::NoProxy}; any other kind must be registered in
+    # {Nonnative.proxies}.
+    #
     # @param kind [String] proxy kind name (for example `"fault_injection"`)
     # @return [Class] a subclass of {Nonnative::Proxy}
+    # @raise [ArgumentError] if the kind is not `"none"` and has not been registered
     def proxy(kind)
       kind.nil? || kind == 'none' ? NoProxy : proxies.fetch(kind) { raise ArgumentError, "Unsupported proxy kind '#{kind}'" }
     end

--- a/lib/nonnative/no_proxy.rb
+++ b/lib/nonnative/no_proxy.rb
@@ -4,8 +4,8 @@ module Nonnative
   # No-op proxy implementation.
   #
   # This is the default proxy when `service.proxy.kind` is `"none"`.
-  # It does not bind/listen or alter traffic; it simply exposes the underlying runner's configured
-  # `host` and primary `port`.
+  # It does not bind/listen or alter traffic; it simply exposes the service configuration's
+  # client-facing `host` and `port`.
   #
   # Services can always call `start`, `stop`, and `reset` safely on this proxy.
   #
@@ -41,7 +41,7 @@ module Nonnative
 
     # Returns the host clients should connect to.
     #
-    # For {NoProxy}, this is the underlying runner configuration host.
+    # For {NoProxy}, this is the service configuration's client-facing `host`.
     #
     # @return [String]
     def host
@@ -50,7 +50,7 @@ module Nonnative
 
     # Returns the port clients should connect to.
     #
-    # For {NoProxy}, this is the first underlying runner configuration port.
+    # For {NoProxy}, this is the service configuration's client-facing `port`.
     #
     # @return [Integer]
     def port

--- a/lib/nonnative/startup.rb
+++ b/lib/nonnative/startup.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Starts the configured Nonnative pool immediately and registers an `at_exit` stop hook.
+#
+# Configure Nonnative before requiring this file; it is intended for suites that keep one
+# Nonnative lifecycle open for the whole Ruby process.
+
 at_exit do
   Nonnative.stop
 end

--- a/nonnative.gemspec
+++ b/nonnative.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Alejandro Falkowski']
   spec.email         = ['alexrfalkowski@gmail.com']
 
-  spec.summary       = 'Allows you to keep using the power of Ruby to test other systems'
-  spec.description   = spec.summary
+  spec.summary       = 'Ruby-first end-to-end harness for testing systems implemented in other languages'
+  spec.description   = 'Starts OS processes, in-process Ruby servers, and proxy-only services with TCP readiness checks and fault-injection proxies.'
   spec.homepage      = 'https://github.com/alexfalkowski/nonnative'
   spec.license       = 'MIT'
   spec.files         = Dir.chdir(File.expand_path(__dir__)) do


### PR DESCRIPTION
## What

- Added contributor bootstrap guidance for initializing the shared `bin/` submodule before using Make targets.
- Clarified the built-in Cucumber manual-start step and public startup/proxy API documentation.
- Updated RubyGems metadata so package-index readers see the gem lifecycle and proxy contract.

## Why

- Fresh-clone contributors need a discoverable setup path before `make help` can load the shared Make fragments.
- Package consumers need the public Cucumber, startup, no-proxy, and proxy-resolution contracts documented at the surfaces they read first.

## Testing

- `make help` - passed
- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- `make sec` - passed
