### PR TITLE
feat(http): harden readiness and startup cleanup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.10.0)
+    nonnative (3.11.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ Process/server fields:
 - `log`: per-runner log file used by process output redirection or server implementations.
 
 Process-only fields:
-- `readiness`: optional HTTP startup readiness check with explicit `port` and `path`.
+- `readiness`: optional HTTP startup readiness check with explicit `port` and path-only `path`.
 
 Service fields:
 - `port`: client-facing service port. Services do not get TCP readiness/shutdown checks from Nonnative.
 
-Nonnative readiness and shutdown checks are TCP port checks by default. Configure process/server ports that are dedicated to the test run; if another process is already listening on the same endpoint, results are undefined. Processes can also opt into an HTTP readiness check that runs after TCP readiness succeeds.
+Nonnative readiness and shutdown checks are TCP port checks by default. Configure process/server ports that are dedicated to the test run; if another process is already listening on the same endpoint, results are undefined. Processes can also opt into an HTTP readiness check that runs after TCP readiness succeeds. HTTP readiness paths must be path-only values, such as `/test/readyz`; absolute URLs and scheme-relative URLs are rejected.
 
 > [!WARNING]
 > TCP readiness and shutdown checks only prove that a TCP port opened or closed. HTTP readiness is process-only, checks for a 2xx response, and does not verify gRPC health, schema readiness, migrations, or other application-specific health.

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -30,6 +30,16 @@ Feature: Configuration loading
       | port  |
       | path  |
 
+  Scenario Outline: YAML rejects process HTTP readiness paths that are not valid path-only values
+    When I attempt to load a temporary configuration with process HTTP readiness path "<path>"
+    Then loading the configuration should fail with an argument error containing "Process readiness path must be path-only"
+
+    Examples:
+      | path                          |
+      | http://example.invalid/readyz |
+      | /test readyz                  |
+      | //example.invalid/readyz      |
+
   Scenario: YAML rejects singular process ports
     When I attempt to load a temporary configuration with a singular runner port
     Then loading the configuration should fail with an argument error containing "Use 'ports' instead of 'port'"

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -303,6 +303,27 @@ When('I attempt to load a temporary configuration with process HTTP readiness mi
   end
 end
 
+When('I attempt to load a temporary configuration with process HTTP readiness path {string}') do |path|
+  capture_result(:@configuration_result, :@configuration_error) do
+    load_temporary_configuration(<<~YAML)
+      version: "1.0"
+      name: test
+      url: http://localhost:4567
+      log: test/reports/nonnative.log
+      processes:
+        - name: invalid_ready_process
+          command: features/support/bin/start 12_426
+          timeout: 1
+          ports:
+            - 12426
+          log: test/reports/12_426.log
+          readiness:
+            port: 12427
+            path: #{path}
+    YAML
+  end
+end
+
 When('I attempt to load a temporary configuration with a Ruby object tag') do
   capture_result(:@configuration_result, :@configuration_error) do
     load_temporary_configuration(<<~YAML)

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -48,6 +48,7 @@ require 'yaml'
 require 'open3'
 require 'securerandom'
 require 'shellwords'
+require 'uri'
 
 require 'grpc'
 require 'sinatra'

--- a/lib/nonnative/configuration_readiness.rb
+++ b/lib/nonnative/configuration_readiness.rb
@@ -9,7 +9,7 @@ module Nonnative
     # @return [Integer] process HTTP readiness port
     attr_accessor :port
 
-    # @return [String] HTTP readiness path
+    # @return [String] path-only HTTP readiness path
     attr_accessor :path
 
     # @param value [Hash, #to_h] readiness attributes
@@ -30,6 +30,15 @@ module Nonnative
     def validate!
       raise ArgumentError, "Process readiness requires 'port'" if port.nil?
       raise ArgumentError, "Process readiness requires 'path'" if path.nil?
+      raise ArgumentError, 'Process readiness path must be path-only' unless path_only?
+    end
+
+    def path_only?
+      uri = URI.parse(path.to_s)
+
+      uri.scheme.nil? && uri.host.nil?
+    rescue URI::InvalidURIError
+      false
     end
   end
 end

--- a/lib/nonnative/cucumber.rb
+++ b/lib/nonnative/cucumber.rb
@@ -43,10 +43,11 @@ module Nonnative
       end
 
       def install_hooks
+        # Register @clear before startup hooks so combined tags reset stale state before creating a pool.
+        Before('@clear') { Nonnative.clear }
         Before('@startup') { Nonnative.start }
         After('@startup') { Nonnative.stop }
         After('@manual') { Nonnative.stop }
-        Before('@clear') { Nonnative.clear }
         After('@reset') { Nonnative.reset }
       end
     end

--- a/lib/nonnative/http_probe.rb
+++ b/lib/nonnative/http_probe.rb
@@ -28,7 +28,7 @@ module Nonnative
       Nonnative.logger.info "checking if readiness '#{endpoint}' is ready"
 
       timeout.perform do
-        response = get(readiness.path)
+        response = get(path)
         raise Nonnative::Error unless ready_response?(response)
 
         true

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.10.0'
+  VERSION = '3.11.0'
 end


### PR DESCRIPTION
## What

- Reject process HTTP readiness paths that contain an absolute URL or scheme-relative host, and use the normalized path when probing.
- Document the path-only readiness contract in README/RDoc.
- Register Cucumber `@clear` before `@startup` so combined lifecycle tags clear stale state before creating a pool.
- Bump `nonnative` to `3.11.0`.

## Why

- Keeps readiness checks bound to the configured process host and port instead of allowing configuration input to redirect probes to another host.
- Prevents `@startup @clear` scenarios from clearing the newly created pool before `@startup` cleanup can stop it.

## Testing

- `make features feature=features/configuration.feature` - passed; covers rejection of absolute and scheme-relative readiness paths.
- `make features` - passed; covers full non-benchmark Cucumber behavior.
- `make benchmarks` - passed; covers benchmark-tagged lifecycle scenarios.
- `make lint` - passed; covers Ruby linting for changed code and feature steps.
- `make sec` - passed; Trivy reported 0 Bundler vulnerabilities in `Gemfile.lock`.

AI-assisted-by: [Codex](https://openai.com/codex/)
