### PR TITLE
feat(health): add grpc readiness probes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.11.0)
+    nonnative (3.12.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It helps you:
 - start **OS processes** (e.g. your Go/Java/Rust service binary),
 - start **in-process Ruby servers** (e.g. small HTTP/TCP/gRPC fakes for dependencies),
 - optionally start **service proxies** for fault-injection in front of externally managed dependencies,
-- wait for readiness/shutdown using **TCP port checks**.
+- wait for readiness/shutdown using **TCP port checks** and optional process HTTP/gRPC checks.
 
 Once started, you can test however you like (TCP, HTTP, gRPC, etc).
 
@@ -79,15 +79,17 @@ Process/server fields:
 - `log`: per-runner log file used by process output redirection or server implementations.
 
 Process-only fields:
-- `readiness`: optional HTTP startup readiness check with explicit `port` and path-only `path`.
+- `readiness`: optional list of startup readiness checks. Supported kinds are `http` and `grpc`.
+  HTTP checks require explicit `port` and path-only `path`. gRPC checks require explicit `port` and
+  health `service`.
 
 Service fields:
 - `port`: client-facing service port. Services do not get TCP readiness/shutdown checks from Nonnative.
 
-Nonnative readiness and shutdown checks are TCP port checks by default. Configure process/server ports that are dedicated to the test run; if another process is already listening on the same endpoint, results are undefined. Processes can also opt into an HTTP readiness check that runs after TCP readiness succeeds. HTTP readiness paths must be path-only values, such as `/test/readyz`; absolute URLs and scheme-relative URLs are rejected.
+Nonnative readiness and shutdown checks are TCP port checks by default. Configure process/server ports that are dedicated to the test run; if another process is already listening on the same endpoint, results are undefined. Processes can also opt into HTTP and gRPC readiness checks that run after TCP readiness succeeds. HTTP readiness paths must be path-only values, such as `/test/readyz`; absolute URLs and scheme-relative URLs are rejected.
 
 > [!WARNING]
-> TCP readiness and shutdown checks only prove that a TCP port opened or closed. HTTP readiness is process-only, checks for a 2xx response, and does not verify gRPC health, schema readiness, migrations, or other application-specific health.
+> TCP readiness and shutdown checks only prove that a TCP port opened or closed. HTTP and gRPC readiness are process-only. HTTP readiness checks for a 2xx response, and gRPC readiness checks the standard gRPC health service for `SERVING`.
 
 Start and stop Nonnative around the test scope that should own the configured runners:
 
@@ -162,6 +164,19 @@ response = Nonnative.observability.health(
 expect(response.code).to eq(200)
 ```
 
+`Nonnative.grpc_health` is a helper for the standard gRPC health checking protocol:
+
+```ruby
+health = Nonnative.grpc_health(
+  host: '127.0.0.1',
+  port: 12_322,
+  service: 'example.v1.ExampleService',
+  timeout: 2
+)
+
+expect(health.serving?).to eq(true)
+```
+
 ### 🔁 Lifecycle strategies (Cucumber integration)
 
 Nonnative ships Cucumber hooks (when loaded) that support these tags/strategies:
@@ -210,7 +225,10 @@ Nonnative.configure do |config|
     p.ports = [12_321]
     p.log = '12_321.log'
     p.signal = 'INT' # Possible values are described in Signal.list.keys.
-    p.readiness = { port: 12_321, path: '/test/readyz' }
+    p.readiness = [
+      { kind: 'http', port: 12_321, path: '/test/readyz' },
+      { kind: 'grpc', port: 12_322, service: 'example.v1.ExampleService' }
+    ]
     p.environment = { # Pass environment variables to process.
       'TEST' => 'true'
     }
@@ -247,8 +265,12 @@ processes:
     log: 12_321.log
     signal: INT # Possible values are described in Signal.list.keys.
     readiness:
-      port: 12321
-      path: /test/readyz
+      - kind: http
+        port: 12321
+        path: /test/readyz
+      - kind: grpc
+        port: 12322
+        service: example.v1.ExampleService
     environment: # Pass environment variables to process.
       TEST: true
   -

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -19,7 +19,15 @@ Feature: Configuration loading
 
   Scenario: YAML maps process HTTP readiness
     Given I load a temporary configuration with process HTTP readiness
-    Then the configured process "ready_process" readiness should use port 12427 and path "/test/readyz"
+    Then the configured process "ready_process" HTTP readiness should use port 12427 and path "/test/readyz"
+
+  Scenario: YAML maps process gRPC readiness
+    Given I load a temporary configuration with process gRPC readiness
+    Then the configured process "ready_process" gRPC readiness should use port 12429 and service "nonnative.v1.GreeterService"
+
+  Scenario: YAML rejects map process readiness
+    When I attempt to load a temporary configuration with map process readiness
+    Then loading the configuration should fail with an argument error containing "Process readiness must be a list of checks"
 
   Scenario Outline: YAML rejects incomplete process HTTP readiness
     When I attempt to load a temporary configuration with process HTTP readiness missing "<field>"
@@ -29,6 +37,18 @@ Feature: Configuration loading
       | field |
       | port  |
       | path  |
+
+  Scenario: YAML rejects incomplete process gRPC readiness
+    When I attempt to load a temporary configuration with process gRPC readiness missing "service"
+    Then loading the configuration should fail with an argument error containing "Process readiness requires 'service'"
+
+  Scenario: YAML rejects process readiness without a kind
+    When I attempt to load a temporary configuration with process HTTP readiness missing "kind"
+    Then loading the configuration should fail with an argument error containing "Process readiness requires 'kind'"
+
+  Scenario: YAML rejects unsupported process readiness kinds
+    When I attempt to load a temporary configuration with process readiness kind "tcp"
+    Then loading the configuration should fail with an argument error containing "Process readiness kind must be one of: http, grpc"
 
   Scenario Outline: YAML rejects process HTTP readiness paths that are not valid path-only values
     When I attempt to load a temporary configuration with process HTTP readiness path "<path>"

--- a/features/processes.feature
+++ b/features/processes.feature
@@ -58,6 +58,24 @@ Feature: Process runners
     When I attempt to start the system
     Then starting the system should raise an error containing "readiness: http://127.0.0.1:12427/test/readyz"
 
+  Scenario: Process gRPC readiness gates startup
+    Given I configure the system programmatically with a process gRPC readiness check
+    And I start the system
+    When I send "test" with the TCP client "grpc_ready_process" to the process
+    Then I should receive a TCP "test" response from the process
+    And the gRPC health helper should report "nonnative.v1.GreeterService" serving on port 12429
+
+  Scenario: Process gRPC readiness uses the configured timeout
+    Given I configure the system programmatically with a slow process gRPC readiness check
+    And I start the system
+    When I send "test" with the TCP client "grpc_ready_process" to the process
+    Then I should receive a TCP "test" response from the process
+
+  Scenario: Process gRPC readiness failures are reported during startup
+    Given I configure the system programmatically with a failing process gRPC readiness check
+    When I attempt to start the system
+    Then starting the system should raise an error containing "readiness: grpc://127.0.0.1:12429/nonnative.v1.GreeterService"
+
   Scenario: Explicit process environment overrides the parent environment
     Given the parent environment variable "STRING" is "parent"
     When I start a process runner with environment "STRING" set to "configured"

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -69,8 +69,30 @@ Given('I load a temporary configuration with process HTTP readiness') do
           - 12426
         log: test/reports/12_426.log
         readiness:
-          port: 12427
-          path: /test/readyz
+          - kind: http
+            port: 12427
+            path: /test/readyz
+  YAML
+end
+
+Given('I load a temporary configuration with process gRPC readiness') do
+  load_temporary_configuration(<<~YAML)
+    version: "1.0"
+    name: test
+    url: http://localhost:4567
+    log: test/reports/nonnative.log
+    processes:
+      - name: ready_process
+        command: features/support/bin/start 12_428
+        timeout: 1
+        host: 127.0.0.1
+        ports:
+          - 12428
+        log: test/reports/12_428.log
+        readiness:
+          - kind: grpc
+            port: 12429
+            service: nonnative.v1.GreeterService
   YAML
 end
 
@@ -280,10 +302,92 @@ When('I attempt to load a temporary configuration with service readiness') do
 end
 
 When('I attempt to load a temporary configuration with process HTTP readiness missing {string}') do |field|
-  readiness = { 'port' => 12_427, 'path' => '/test/readyz' }
-  readiness.delete(field)
-  readiness_yaml = readiness.map { |key, value| "#{key}: #{value}" }.join("\n")
+  capture_result(:@configuration_result, :@configuration_error) do
+    case field
+    when 'kind'
+      load_temporary_configuration(<<~YAML)
+        version: "1.0"
+        name: test
+        url: http://localhost:4567
+        log: test/reports/nonnative.log
+        processes:
+          - name: incomplete_ready_process
+            command: features/support/bin/start 12_426
+            timeout: 1
+            ports:
+              - 12426
+            log: test/reports/12_426.log
+            readiness:
+              - port: 12427
+                path: /test/readyz
+      YAML
+    when 'port'
+      load_temporary_configuration(<<~YAML)
+        version: "1.0"
+        name: test
+        url: http://localhost:4567
+        log: test/reports/nonnative.log
+        processes:
+          - name: incomplete_ready_process
+            command: features/support/bin/start 12_426
+            timeout: 1
+            ports:
+              - 12426
+            log: test/reports/12_426.log
+            readiness:
+              - kind: http
+                path: /test/readyz
+      YAML
+    when 'path'
+      load_temporary_configuration(<<~YAML)
+        version: "1.0"
+        name: test
+        url: http://localhost:4567
+        log: test/reports/nonnative.log
+        processes:
+          - name: incomplete_ready_process
+            command: features/support/bin/start 12_426
+            timeout: 1
+            ports:
+              - 12426
+            log: test/reports/12_426.log
+            readiness:
+              - kind: http
+                port: 12427
+      YAML
+    else
+      raise ArgumentError, "Unknown readiness field '#{field}'"
+    end
+  end
+end
 
+When('I attempt to load a temporary configuration with process gRPC readiness missing {string}') do |field|
+  capture_result(:@configuration_result, :@configuration_error) do
+    case field
+    when 'service'
+      load_temporary_configuration(<<~YAML)
+        version: "1.0"
+        name: test
+        url: http://localhost:4567
+        log: test/reports/nonnative.log
+        processes:
+          - name: incomplete_ready_process
+            command: features/support/bin/start 12_428
+            timeout: 1
+            ports:
+              - 12428
+            log: test/reports/12_428.log
+            readiness:
+              - kind: grpc
+                port: 12429
+      YAML
+    else
+      raise ArgumentError, "Unknown readiness field '#{field}'"
+    end
+  end
+end
+
+When('I attempt to load a temporary configuration with map process readiness') do
   capture_result(:@configuration_result, :@configuration_error) do
     load_temporary_configuration(<<~YAML)
       version: "1.0"
@@ -291,14 +395,37 @@ When('I attempt to load a temporary configuration with process HTTP readiness mi
       url: http://localhost:4567
       log: test/reports/nonnative.log
       processes:
-        - name: incomplete_ready_process
+        - name: map_ready_process
           command: features/support/bin/start 12_426
           timeout: 1
           ports:
             - 12426
           log: test/reports/12_426.log
           readiness:
-            #{readiness_yaml}
+            kind: http
+            port: 12427
+            path: /test/readyz
+    YAML
+  end
+end
+
+When('I attempt to load a temporary configuration with process readiness kind {string}') do |kind|
+  capture_result(:@configuration_result, :@configuration_error) do
+    load_temporary_configuration(<<~YAML)
+      version: "1.0"
+      name: test
+      url: http://localhost:4567
+      log: test/reports/nonnative.log
+      processes:
+        - name: unsupported_ready_process
+          command: features/support/bin/start 12_426
+          timeout: 1
+          ports:
+            - 12426
+          log: test/reports/12_426.log
+          readiness:
+            - kind: #{kind}
+              port: 12427
     YAML
   end
 end
@@ -318,8 +445,9 @@ When('I attempt to load a temporary configuration with process HTTP readiness pa
             - 12426
           log: test/reports/12_426.log
           readiness:
-            port: 12427
-            path: #{path}
+            - kind: http
+              port: 12427
+              path: #{path}
     YAML
   end
 end
@@ -420,11 +548,20 @@ Then('the configured process {string} should use ports:') do |name, table|
   expect(process.ports).to eq(table.raw.flatten.map(&:to_i))
 end
 
-Then('the configured process {string} readiness should use port {int} and path {string}') do |name, port, path|
+Then('the configured process {string} HTTP readiness should use port {int} and path {string}') do |name, port, path|
   process = configured_process(name)
+  readiness = process.readiness.find(&:http?)
 
-  expect(process.readiness.port).to eq(port)
-  expect(process.readiness.path).to eq(path)
+  expect(readiness.port).to eq(port)
+  expect(readiness.path).to eq(path)
+end
+
+Then('the configured process {string} gRPC readiness should use port {int} and service {string}') do |name, port, service|
+  process = configured_process(name)
+  readiness = process.readiness.find(&:grpc?)
+
+  expect(readiness.port).to eq(port)
+  expect(readiness.service).to eq(service)
 end
 
 Then('the configured service {string} proxy should use host {string} and port {int}') do |name, host, port|

--- a/features/step_definitions/lifecycle_steps.rb
+++ b/features/step_definitions/lifecycle_steps.rb
@@ -119,23 +119,7 @@ When('I require {string} in a subprocess') do |path|
 end
 
 When('I require {string} in an instrumented subprocess') do |path|
-  run_subprocess(<<~RUBY)
-    require 'nonnative'
-
-    module Nonnative
-      class << self
-        def start
-          puts 'started'
-        end
-
-        def stop
-          puts 'stopped'
-        end
-      end
-    end
-
-    require #{path.inspect}
-  RUBY
+  run_subprocess(startup_hook_recording_script(path))
 end
 
 Then('starting the system should raise an error containing {string}') do |message|

--- a/features/step_definitions/processes_steps.rb
+++ b/features/step_definitions/processes_steps.rb
@@ -76,6 +76,18 @@ Given('I configure the system programmatically with a failing process HTTP readi
   configure_http_readiness_process(status: 503)
 end
 
+Given('I configure the system programmatically with a process gRPC readiness check') do
+  configure_grpc_readiness_process(status: :SERVING)
+end
+
+Given('I configure the system programmatically with a slow process gRPC readiness check') do
+  configure_grpc_readiness_process(status: :SERVING, delay: 0.2)
+end
+
+Given('I configure the system programmatically with a failing process gRPC readiness check') do
+  configure_grpc_readiness_process(status: :NOT_SERVING)
+end
+
 Given('the parent environment variable {string} is {string}') do |name, value|
   @previous_environment ||= {}
   @previous_environment[name] = ENV.fetch(name, nil)
@@ -121,6 +133,12 @@ end
 
 Then('I should receive a TCP {string} response from the process') do |response|
   expect(@response).to eq(response)
+end
+
+Then('the gRPC health helper should report {string} serving on port {int}') do |service, port|
+  health = Nonnative.grpc_health(host: '127.0.0.1', port: port, service: service, timeout: 1)
+
+  expect(health.serving?).to be(true)
 end
 
 Then('the argv process shell side effect should not happen') do

--- a/features/support/bin/grpc_readiness
+++ b/features/support/bin/grpc_readiness
@@ -1,0 +1,82 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'socket'
+require 'grpc'
+require 'grpc/health/v1/health_services_pb'
+
+tcp_port = ARGV.fetch(0).to_i
+grpc_port = ARGV.fetch(1).to_i
+service = ARGV.fetch(2)
+status = ARGV.fetch(3).to_sym
+delay = ARGV.fetch(4, '0').to_f
+
+class HealthService < Grpc::Health::V1::Health::Service
+  def initialize(service, status, delay)
+    super()
+
+    @service = service
+    @status = status
+    @delay = delay
+  end
+
+  def check(request, _call)
+    sleep delay
+
+    response_status = request.service == service ? status : :SERVICE_UNKNOWN
+
+    Grpc::Health::V1::HealthCheckResponse.new(status: response_status)
+  end
+
+  private
+
+  attr_reader :delay, :service, :status
+end
+
+closing = false
+tcp_server = TCPServer.new('0.0.0.0', tcp_port)
+grpc_server = GRPC::RpcServer.new
+grpc_server.add_http2_port("0.0.0.0:#{grpc_port}", :this_port_is_insecure)
+grpc_server.handle(HealthService.new(service, status, delay))
+
+Signal.trap 'INT' do
+  closing = true
+end
+
+Signal.trap 'TERM' do
+  closing = true
+end
+
+Thread.new do
+  grpc_server.run_till_terminated
+end
+
+Thread.new do
+  loop do
+    tcp_server.close if closing && !tcp_server.closed?
+    grpc_server.stop if closing
+    exit if closing
+
+    sleep 0.01
+  rescue IOError
+    exit
+  end
+end
+
+Thread.new do
+  loop do
+    socket = tcp_server.accept
+    Thread.new(socket) do |conn|
+      loop do
+        line = conn.readline.strip
+        conn.puts(line)
+      end
+    rescue EOFError
+      conn.close
+    end
+  end
+rescue IOError, Errno::EBADF
+  nil
+end
+
+sleep

--- a/features/support/context/lifecycle_support.rb
+++ b/features/support/context/lifecycle_support.rb
@@ -90,6 +90,27 @@ module Nonnative
             chdir: Dir.pwd
           )
         end
+
+        def startup_hook_recording_script(path)
+          # Define observable lifecycle hooks before requiring nonnative/startup.
+          <<~RUBY
+            require 'nonnative'
+
+            module Nonnative
+              class << self
+                def start
+                  puts 'started'
+                end
+
+                def stop
+                  puts 'stopped'
+                end
+              end
+            end
+
+            require #{path.inspect}
+          RUBY
+        end
       end
     end
   end

--- a/features/support/context/process_configuration.rb
+++ b/features/support/context/process_configuration.rb
@@ -37,6 +37,12 @@ module Nonnative
           end
         end
 
+        def configure_grpc_readiness_process(status:, delay: 0)
+          configure_with_defaults do |config|
+            add_process(config, grpc_readiness_process(status, delay))
+          end
+        end
+
         private
 
         def http_readiness_process(status)
@@ -49,8 +55,35 @@ module Nonnative
             ports: [12_426],
             log: 'test/reports/12_426.log',
             signal: 'INT',
-            readiness: { port: 12_427, path: '/test/readyz' }
+            readiness: [{ kind: 'http', port: 12_427, path: '/test/readyz' }]
           }
+        end
+
+        def grpc_readiness_process(status, delay)
+          {
+            name: 'grpc_ready_process',
+            command: -> { grpc_readiness_command(status, delay) },
+            timeout: 2,
+            wait: 0.1,
+            host: '127.0.0.1',
+            ports: [12_428, 12_429],
+            log: 'test/reports/12_428.log',
+            signal: 'INT',
+            readiness: [{ kind: 'grpc', port: 12_429, service: 'nonnative.v1.GreeterService' }]
+          }
+        end
+
+        def grpc_readiness_command(status, delay)
+          [
+            RbConfig.ruby,
+            '-rbundler/setup',
+            'features/support/bin/grpc_readiness',
+            '12428',
+            '12429',
+            'nonnative.v1.GreeterService',
+            status.to_s,
+            delay.to_s
+          ]
         end
 
         def add_process(config, definition)

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -6,7 +6,7 @@
 # It can:
 #
 # - start external processes and in-process servers
-# - wait for readiness via port checks and optional process HTTP readiness
+# - wait for readiness via port checks and optional process HTTP/gRPC readiness
 # - optionally run fault-injection proxies in front of services
 #
 # The public entry points are exposed as module-level methods on {Nonnative}.
@@ -27,7 +27,7 @@
 #       p.ports = [8080, 9090]
 #       p.timeout = 10
 #       p.log = 'api.log'
-#       p.readiness = { port: 8080, path: '/example/readyz' }
+#       p.readiness = [{ kind: 'http', port: 8080, path: '/example/readyz' }]
 #     end
 #   end
 #
@@ -51,6 +51,7 @@ require 'shellwords'
 require 'uri'
 
 require 'grpc'
+require 'grpc/health/v1/health_services_pb'
 require 'sinatra'
 require 'rest-client'
 require 'retriable'
@@ -86,6 +87,8 @@ require 'nonnative/service'
 require 'nonnative/pool'
 require 'nonnative/http_client'
 require 'nonnative/http_probe'
+require 'nonnative/grpc_health'
+require 'nonnative/grpc_probe'
 require 'nonnative/http_server'
 require 'nonnative/http_proxy_server'
 require 'nonnative/grpc_server'
@@ -190,9 +193,16 @@ module Nonnative
     # Returns an HTTP client for common health/readiness endpoints.
     #
     # @return [Nonnative::Observability]
-    def observability
-      @observability ||= Nonnative::Observability.new(configuration.url)
-    end
+    def observability = (@observability ||= Nonnative::Observability.new(configuration.url))
+
+    # Returns a client helper for the standard gRPC health checking protocol.
+    #
+    # @param host [String] gRPC server host
+    # @param port [Integer] gRPC server port
+    # @param service [String] gRPC health service name
+    # @param timeout [Numeric] default call timeout in seconds
+    # @return [Nonnative::GRPCHealth]
+    def grpc_health(host:, port:, service:, timeout: 1) = Nonnative::GRPCHealth.new(host: host, port: port, service: service, timeout: timeout)
 
     # Returns the configured proxy kinds mapped to proxy classes.
     #

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -22,7 +22,7 @@ module Nonnative
   #       p.ports = [8080, 9090]
   #       p.timeout = 10
   #       p.log = 'api.log'
-  #       p.readiness = { port: 8080, path: '/example/readyz' }
+  #       p.readiness = [{ kind: 'http', port: 8080, path: '/example/readyz' }]
   #     end
   #   end
   #

--- a/lib/nonnative/configuration_process.rb
+++ b/lib/nonnative/configuration_process.rb
@@ -28,7 +28,7 @@ module Nonnative
     # @return [Hash, nil] environment variables to pass to the spawned process
     attr_accessor :environment
 
-    # @return [Nonnative::ConfigurationReadiness, nil] optional HTTP readiness check
+    # @return [Array<Nonnative::ConfigurationReadiness>] optional readiness checks
     attr_reader :readiness
 
     # Creates a process configuration with bounded lifecycle defaults.
@@ -41,14 +41,23 @@ module Nonnative
       super
 
       self.timeout = DEFAULT_TIMEOUT
+      self.readiness = []
     end
 
-    # Sets optional HTTP readiness configuration.
+    # Sets optional process readiness checks.
     #
-    # @param value [Hash, #to_h, nil] readiness attributes with required `port` and `path`
+    # @param value [Array<Hash, #to_h>, nil] readiness checks with required `kind` and `port`
     # @return [void]
     def readiness=(value)
-      @readiness = value.nil? ? nil : Nonnative::ConfigurationReadiness.new(value)
+      @readiness = value.nil? ? [] : build_readiness(value)
+    end
+
+    private
+
+    def build_readiness(value)
+      raise ArgumentError, 'Process readiness must be a list of checks' unless value.is_a?(Array)
+
+      value.map { |check| Nonnative::ConfigurationReadiness.new(check) }
     end
   end
 end

--- a/lib/nonnative/configuration_readiness.rb
+++ b/lib/nonnative/configuration_readiness.rb
@@ -1,24 +1,42 @@
 # frozen_string_literal: true
 
 module Nonnative
-  # HTTP readiness configuration for a managed process.
+  # Readiness check configuration for a managed process.
   #
-  # Readiness is optional. When present, both `port` and `path` are required so the startup
-  # check has an explicit application endpoint to poll after TCP readiness succeeds.
+  # Readiness is optional. When present, each check declares a `kind` and explicit endpoint details
+  # to poll after TCP readiness succeeds.
   class ConfigurationReadiness
-    # @return [Integer] process HTTP readiness port
+    KINDS = %w[http grpc].freeze
+
+    # @return [String] readiness check kind
+    attr_accessor :kind
+
+    # @return [Integer] process readiness port
     attr_accessor :port
 
     # @return [String] path-only HTTP readiness path
     attr_accessor :path
 
-    # @param value [Hash, #to_h] readiness attributes
+    # @return [String] gRPC health service name
+    attr_accessor :service
+
+    # @param value [Hash, #to_h] readiness check attributes
     def initialize(value)
       attributes = value.respond_to?(:to_h) ? value.to_h : value
+      self.kind = attribute(attributes, :kind)&.to_s
       self.port = attribute(attributes, :port)
       self.path = attribute(attributes, :path)
+      self.service = attribute(attributes, :service)
 
       validate!
+    end
+
+    def http?
+      kind == 'http'
+    end
+
+    def grpc?
+      kind == 'grpc'
     end
 
     private
@@ -28,9 +46,21 @@ module Nonnative
     end
 
     def validate!
+      raise ArgumentError, "Process readiness requires 'kind'" if kind.nil?
+      raise ArgumentError, "Process readiness kind must be one of: #{KINDS.join(', ')}" unless KINDS.include?(kind)
       raise ArgumentError, "Process readiness requires 'port'" if port.nil?
+
+      validate_http! if http?
+      validate_grpc! if grpc?
+    end
+
+    def validate_http!
       raise ArgumentError, "Process readiness requires 'path'" if path.nil?
       raise ArgumentError, 'Process readiness path must be path-only' unless path_only?
+    end
+
+    def validate_grpc!
+      raise ArgumentError, "Process readiness requires 'service'" if service.nil?
     end
 
     def path_only?

--- a/lib/nonnative/grpc_health.rb
+++ b/lib/nonnative/grpc_health.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Nonnative
+  # Client helper for the standard gRPC health checking protocol.
+  class GRPCHealth
+    NETWORK_ERRORS = [
+      GRPC::BadStatus,
+      GRPC::Core::CallError
+    ].freeze
+
+    # @param host [String] gRPC server host
+    # @param port [Integer] gRPC server port
+    # @param service [String] gRPC health service name
+    # @param timeout [Numeric] default call timeout in seconds
+    def initialize(host:, port:, service:, timeout: 1)
+      @host = host
+      @port = port
+      @service = service.to_s
+      @timeout = timeout
+    end
+
+    # Calls the gRPC health check endpoint.
+    #
+    # @param deadline [Time] gRPC deadline
+    # @return [Grpc::Health::V1::HealthCheckResponse]
+    def check(deadline: Time.now + timeout)
+      stub.check(request, deadline: deadline)
+    end
+
+    # Returns true when the gRPC health endpoint reports SERVING.
+    #
+    # @param deadline [Time] gRPC deadline
+    # @return [Boolean]
+    def serving?(deadline: Time.now + timeout)
+      check(deadline: deadline).status == :SERVING
+    rescue *NETWORK_ERRORS
+      false
+    end
+
+    # Returns the checked gRPC health endpoint for lifecycle diagnostics.
+    #
+    # @return [String]
+    def endpoint
+      service.empty? ? "grpc://#{host}:#{port}" : "grpc://#{host}:#{port}/#{service}"
+    end
+
+    private
+
+    attr_reader :host, :port, :service, :timeout
+
+    def request
+      Grpc::Health::V1::HealthCheckRequest.new(service: service)
+    end
+
+    def stub
+      @stub ||= Grpc::Health::V1::Health::Stub.new("#{host}:#{port}", :this_channel_is_insecure)
+    end
+  end
+end

--- a/lib/nonnative/grpc_probe.rb
+++ b/lib/nonnative/grpc_probe.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Nonnative
+  # Probes a managed process gRPC health endpoint.
+  class GRPCProbe
+    # @param process [Nonnative::ConfigurationProcess] process configuration
+    # @param readiness [Nonnative::ConfigurationReadiness] gRPC readiness attributes
+    def initialize(process, readiness)
+      @health = Nonnative::GRPCHealth.new(
+        host: process.host,
+        port: readiness.port,
+        service: readiness.service,
+        timeout: process.timeout
+      )
+      @timeout = Nonnative::Timeout.new(process.timeout)
+    end
+
+    # Returns whether the configured gRPC health endpoint reports SERVING before timeout.
+    #
+    # @return [Boolean]
+    def ready?
+      Nonnative.logger.info "checking if readiness '#{endpoint}' is ready"
+
+      timeout.perform do
+        raise Nonnative::Error unless health.serving?
+
+        true
+      rescue Nonnative::Error
+        sleep_interval
+        retry
+      end
+    end
+
+    # Returns the gRPC health endpoint for lifecycle diagnostics.
+    #
+    # @return [String]
+    def endpoint
+      health.endpoint
+    end
+
+    private
+
+    attr_reader :health, :timeout
+
+    def sleep_interval
+      sleep 0.01
+    end
+  end
+end

--- a/lib/nonnative/http_probe.rb
+++ b/lib/nonnative/http_probe.rb
@@ -12,9 +12,10 @@ module Nonnative
       RestClient::ServerBrokeConnection
     ].freeze
 
-    # @param process [Nonnative::ConfigurationProcess] process configuration with readiness attributes
-    def initialize(process)
-      @readiness = process.readiness
+    # @param process [Nonnative::ConfigurationProcess] process configuration
+    # @param readiness [Nonnative::ConfigurationReadiness] HTTP readiness attributes
+    def initialize(process, readiness)
+      @readiness = readiness
       @base_url = "http://#{process.host}:#{readiness.port}"
       @timeout = Nonnative::Timeout.new(process.timeout)
 

--- a/lib/nonnative/ports.rb
+++ b/lib/nonnative/ports.rb
@@ -12,14 +12,14 @@ module Nonnative
     def initialize(runner)
       @runner = runner
       @ports = runner.ports.map { |port| Nonnative::Port.new(runner, port) }
-      @readiness = Nonnative::HTTPProbe.new(runner) if runner.respond_to?(:readiness) && runner.readiness
+      @readiness = readiness_probes
     end
 
     # Returns whether all configured ports become connectable before their timeouts elapse.
     #
     # @return [Boolean]
     def open?
-      ports.all?(&:open?) && (readiness.nil? || readiness.ready?)
+      ports.all?(&:open?) && readiness.all?(&:ready?)
     end
 
     # Returns whether all configured ports become non-connectable before their timeouts elapse.
@@ -41,7 +41,7 @@ module Nonnative
     # @return [String]
     def description
       details = []
-      details << "readiness: #{readiness.endpoint}" if readiness
+      details << "readiness: #{readiness.map(&:endpoint).join(', ')}" if readiness.any?
       log = runner.log if runner.respond_to?(:log)
       details << "log: #{log}" if log
 
@@ -51,5 +51,20 @@ module Nonnative
     private
 
     attr_reader :ports, :readiness, :runner
+
+    def readiness_probes
+      return [] unless runner.respond_to?(:readiness)
+
+      runner.readiness.map { |check| readiness_probe(check) }
+    end
+
+    def readiness_probe(check)
+      case check.kind
+      when 'http'
+        Nonnative::HTTPProbe.new(runner, check)
+      when 'grpc'
+        Nonnative::GRPCProbe.new(runner, check)
+      end
+    end
   end
 end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.11.0'
+  VERSION = '3.12.0'
 end


### PR DESCRIPTION
## What

- Add typed process readiness checks so HTTP and gRPC readiness can run after TCP port readiness.
- Add `Nonnative.grpc_health(...)` and a `Nonnative::GRPCHealth` helper for the standard gRPC health checking protocol.
- Update README examples and bump the gem version to 3.12.0.
- This intentionally breaks the previous single-map `readiness:` shape; process readiness now uses a list with explicit `kind` values.

## Why

- Downstream services expose gRPC health endpoints but had to duplicate gRPC health stub setup in test code.
- Startup readiness can now verify that a gRPC process is actually serving instead of only proving that its TCP port opened.
- The explicit list format lets HTTP and gRPC readiness checks coexist without ambiguous configuration.

## Testing

- `make lint` - passed
- `make sec` - passed
- `make features feature=features/processes.feature` - failed before the timeout fix for slow gRPC health responses, then passed after the fix
- `make features` - passed
- `make benchmarks` - passed
- Added Cucumber coverage for HTTP/gRPC readiness config, invalid readiness config, gRPC readiness success/failure, gRPC helper usage, and configured-timeout behavior.

AI-assisted-by: [Codex](https://openai.com/codex/)
