### PR TITLE
feat(health): check external dependencies before startup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.12.0)
+    nonnative (3.13.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It helps you:
 - start **OS processes** (e.g. your Go/Java/Rust service binary),
 - start **in-process Ruby servers** (e.g. small HTTP/TCP/gRPC fakes for dependencies),
 - optionally start **service proxies** for fault-injection in front of externally managed dependencies,
-- wait for readiness/shutdown using **TCP port checks** and optional process HTTP/gRPC checks.
+- wait for readiness/shutdown using **TCP port checks**, optional process HTTP/gRPC checks, and optional service TCP checks.
 
 Once started, you can test however you like (TCP, HTTP, gRPC, etc).
 
@@ -84,12 +84,15 @@ Process-only fields:
   health `service`.
 
 Service fields:
-- `port`: client-facing service port. Services do not get TCP readiness/shutdown checks from Nonnative.
+- `port`: client-facing service port.
+- `timeout`: max time (seconds) for opt-in service readiness checks. Defaults to `1.0`.
+- `readiness`: optional list of startup readiness checks. Supported kind is `tcp`, which requires
+  explicit `host` and `port`.
 
-Nonnative readiness and shutdown checks are TCP port checks by default. Configure process/server ports that are dedicated to the test run; if another process is already listening on the same endpoint, results are undefined. Processes can also opt into HTTP and gRPC readiness checks that run after TCP readiness succeeds. HTTP readiness paths must be path-only values, such as `/test/readyz`; absolute URLs and scheme-relative URLs are rejected.
+Nonnative readiness and shutdown checks are TCP port checks by default. Configure process/server ports that are dedicated to the test run; if another process is already listening on the same endpoint, results are undefined. Processes can also opt into HTTP and gRPC readiness checks that run after TCP readiness succeeds. Services do not get automatic TCP readiness/shutdown checks, but can opt into TCP startup readiness for externally managed dependencies. HTTP readiness paths must be path-only values, such as `/test/readyz`; absolute URLs and scheme-relative URLs are rejected.
 
 > [!WARNING]
-> TCP readiness and shutdown checks only prove that a TCP port opened or closed. HTTP and gRPC readiness are process-only. HTTP readiness checks for a 2xx response, and gRPC readiness checks the standard gRPC health service for `SERVING`.
+> TCP readiness and shutdown checks only prove that a TCP port opened or closed. HTTP and gRPC readiness are process-only. Service readiness is TCP-only and should target the dependency endpoint that must be reachable before managed servers/processes start.
 
 Start and stop Nonnative around the test scope that should own the configured runners:
 
@@ -615,7 +618,7 @@ end
 
 A service is an external dependency to your system that you **do not** want Nonnative to start (no OS process, no Ruby thread).
 
-Services do not get process lifecycle management or TCP readiness/shutdown checks from Nonnative. They provide a named endpoint for a dependency that another tool already manages.
+Services do not get process lifecycle management or automatic TCP readiness/shutdown checks from Nonnative. They provide a named endpoint for a dependency that another tool already manages, and can opt into TCP startup readiness when the dependency must be reachable before managed servers/processes start.
 
 Set it up programmatically:
 
@@ -632,6 +635,8 @@ Nonnative.configure do |config|
     s.name = 'postgres'
     s.host = '127.0.0.1'
     s.port = 5432
+    s.timeout = 5
+    s.readiness = [{ kind: 'tcp', host: '127.0.0.1', port: 5432 }]
   end
 
   config.service do |s|
@@ -654,6 +659,11 @@ services:
     name: postgres
     host: 127.0.0.1
     port: 5432
+    timeout: 5
+    readiness:
+      - kind: tcp
+        host: 127.0.0.1
+        port: 5432
   -
     name: redis
     host: 127.0.0.1
@@ -687,6 +697,7 @@ Nonnative.proxies['custom'] = CustomProxy
 ```
 
 Only services support proxies. For `fault_injection`, keep the service `host`/`port` as the client-facing proxy endpoint and use nested `proxy.host`/`proxy.port` for the upstream target behind the proxy.
+When service readiness is configured for a proxied dependency, set the readiness `host`/`port` to the upstream dependency, not the client-facing proxy listener.
 
 ##### 🧩 Service Proxies
 
@@ -710,6 +721,8 @@ config.service do |s|
       delay: 5
     }
   }
+
+  s.readiness = [{ kind: 'tcp', host: '127.0.0.1', port: 6379 }]
 end
 ```
 
@@ -723,6 +736,10 @@ services:
     name: redis
     host: 127.0.0.1
     port: 16379
+    readiness:
+      - kind: tcp
+        host: 127.0.0.1
+        port: 6379
     proxy:
       kind: fault_injection
       host: 127.0.0.1

--- a/features/configs/services.yml
+++ b/features/configs/services.yml
@@ -6,6 +6,10 @@ services:
   - name: service_1
     host: 127.0.0.1
     port: 20006
+    readiness:
+      - kind: tcp
+        host: 127.0.0.1
+        port: 30000
     proxy:
       kind: fault_injection
       host: 127.0.0.1

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -11,6 +11,10 @@ Feature: Configuration loading
     Then the configured service "service_1" should use host "127.0.0.1" and port 20006
     And the configured service "service_1" proxy should use host "127.0.0.1" and port 30000
 
+  Scenario: YAML maps service TCP readiness
+    Given I load a temporary configuration with service TCP readiness
+    Then the configured service "service_1" TCP readiness should use host "127.0.0.1" and port 30000
+
   Scenario: YAML maps multiple runner ports
     Given I load a temporary configuration with multiple runner ports
     Then the configured process "multi_port_process" should use ports:
@@ -92,9 +96,18 @@ Feature: Configuration loading
     When I attempt to load a temporary configuration with server readiness
     Then loading the configuration should fail with an argument error containing "servers do not support 'readiness'"
 
-  Scenario: YAML rejects service readiness
-    When I attempt to load a temporary configuration with service readiness
-    Then loading the configuration should fail with an argument error containing "services do not support 'readiness'"
+  Scenario Outline: YAML rejects incomplete service TCP readiness
+    When I attempt to load a temporary configuration with service TCP readiness missing "<field>"
+    Then loading the configuration should fail with an argument error containing "Service readiness requires '<field>'"
+
+    Examples:
+      | field |
+      | host  |
+      | port  |
+
+  Scenario: YAML rejects unsupported service readiness kinds
+    When I attempt to load a temporary configuration with service readiness kind "http"
+    Then loading the configuration should fail with an argument error containing "Service readiness kind must be one of: tcp"
 
   Scenario: Server YAML class entries resolve to server implementations
     Given I load a temporary configuration with a server entry

--- a/features/services.feature
+++ b/features/services.feature
@@ -22,6 +22,23 @@ Feature: Service proxies
     And I start the system
     Then the proxy for service "service_1" should use host "127.0.0.1" and port 30000
 
+  Scenario: Service TCP readiness gates startup
+    Given I configure the system programmatically with service TCP readiness
+    And I start the system
+    When I connect to the service
+    Then I should have a successful connection
+
+  Scenario: Service TCP readiness failures are reported during startup
+    Given I configure the system programmatically with missing service TCP readiness
+    When I attempt to start the system
+    Then starting the system should raise an error containing "readiness: 127.0.0.1:30001"
+
+  Scenario: Service TCP readiness failures stop startup before processes
+    Given I configure the system programmatically with a process and missing service TCP readiness
+    When I attempt to start the system
+    Then starting the system should raise an error containing "readiness: 127.0.0.1:30001"
+    And the service readiness process side effect should not happen
+
   @reset
   Scenario: Services can run without proxies
     Given I configure the system programmatically with services without proxies

--- a/features/step_definitions/configuration_steps.rb
+++ b/features/step_definitions/configuration_steps.rb
@@ -36,6 +36,28 @@ Given('I load a temporary configuration with split service and proxy endpoints')
   YAML
 end
 
+Given('I load a temporary configuration with service TCP readiness') do
+  load_temporary_configuration(<<~YAML)
+    version: "1.0"
+    name: test
+    url: http://localhost:4567
+    log: test/reports/nonnative.log
+    services:
+      - name: service_1
+        host: 127.0.0.1
+        port: 20006
+        readiness:
+          - kind: tcp
+            host: 127.0.0.1
+            port: 30000
+        proxy:
+          kind: fault_injection
+          host: 127.0.0.1
+          port: 30000
+          log: test/reports/proxy_service_1.log
+  YAML
+end
+
 Given('I load a temporary configuration with multiple runner ports') do
   load_temporary_configuration(<<~YAML)
     version: "1.0"
@@ -284,7 +306,42 @@ When('I attempt to load a temporary configuration with server readiness') do
   end
 end
 
-When('I attempt to load a temporary configuration with service readiness') do
+When('I attempt to load a temporary configuration with service TCP readiness missing {string}') do |field|
+  capture_result(:@configuration_result, :@configuration_error) do
+    case field
+    when 'host'
+      load_temporary_configuration(<<~YAML)
+        version: "1.0"
+        name: test
+        url: http://localhost:4567
+        log: test/reports/nonnative.log
+        services:
+          - name: service_readiness
+            port: 12426
+            readiness:
+              - kind: tcp
+                port: 12427
+      YAML
+    when 'port'
+      load_temporary_configuration(<<~YAML)
+        version: "1.0"
+        name: test
+        url: http://localhost:4567
+        log: test/reports/nonnative.log
+        services:
+          - name: service_readiness
+            port: 12426
+            readiness:
+              - kind: tcp
+                host: 127.0.0.1
+      YAML
+    else
+      raise ArgumentError, "Unknown readiness field '#{field}'"
+    end
+  end
+end
+
+When('I attempt to load a temporary configuration with service readiness kind {string}') do |kind|
   capture_result(:@configuration_result, :@configuration_error) do
     load_temporary_configuration(<<~YAML)
       version: "1.0"
@@ -295,8 +352,9 @@ When('I attempt to load a temporary configuration with service readiness') do
         - name: service_readiness
           port: 12426
           readiness:
-            port: 12427
-            path: /test/readyz
+            - kind: #{kind}
+              host: 127.0.0.1
+              port: 12427
     YAML
   end
 end
@@ -562,6 +620,14 @@ Then('the configured process {string} gRPC readiness should use port {int} and s
 
   expect(readiness.port).to eq(port)
   expect(readiness.service).to eq(service)
+end
+
+Then('the configured service {string} TCP readiness should use host {string} and port {int}') do |name, host, port|
+  service = configured_service(name)
+  readiness = service.readiness.find(&:tcp?)
+
+  expect(readiness.host).to eq(host)
+  expect(readiness.port).to eq(port)
 end
 
 Then('the configured service {string} proxy should use host {string} and port {int}') do |name, host, port|

--- a/features/step_definitions/services_steps.rb
+++ b/features/step_definitions/services_steps.rb
@@ -12,6 +12,18 @@ Given('I configure the system programmatically with services and missing upstrea
   configure_services_with_missing_upstreams_programmatically
 end
 
+Given('I configure the system programmatically with service TCP readiness') do
+  configure_services_with_tcp_readiness_programmatically
+end
+
+Given('I configure the system programmatically with missing service TCP readiness') do
+  configure_services_with_missing_tcp_readiness_programmatically
+end
+
+Given('I configure the system programmatically with a process and missing service TCP readiness') do
+  configure_process_with_missing_service_tcp_readiness_programmatically
+end
+
 Given('I configure the system through configuration with services') do
   load_configuration('features/configs/services.yml')
 end
@@ -69,6 +81,10 @@ end
 
 Then('stopping the service runner should succeed') do
   expect(@stop_error).to be_nil
+end
+
+Then('the service readiness process side effect should not happen') do
+  expect(File.exist?(@service_readiness_process_output)).to eq(false)
 end
 
 Then('the proxy for service {string} should use host {string} and port {int}') do |name, host, port|

--- a/features/support/context.rb
+++ b/features/support/context.rb
@@ -6,6 +6,7 @@ require_relative 'context/process_configuration'
 require_relative 'context/server_configuration'
 require_relative 'context/http_proxy_configuration'
 require_relative 'context/service_configuration'
+require_relative 'context/service_readiness_configuration'
 require_relative 'context/service_connections'
 require_relative 'context/benchmark_configuration'
 require_relative 'context/endpoint_clients'
@@ -26,6 +27,7 @@ module Nonnative
       include ServerConfiguration
       include HTTPProxyConfiguration
       include ServiceConfiguration
+      include ServiceReadinessConfiguration
       include ServiceConnections
       include BenchmarkConfiguration
       include EndpointClients

--- a/features/support/context/service_configuration.rb
+++ b/features/support/context/service_configuration.rb
@@ -73,6 +73,8 @@ module Nonnative
             service.name = definition[:name]
             service.host = definition[:host]
             service.port = definition[:port]
+            service.timeout = definition[:timeout] if definition[:timeout]
+            service.readiness = definition[:readiness] if definition[:readiness]
             service.proxy = definition[:proxy] if definition[:proxy]
           end
         end

--- a/features/support/context/service_readiness_configuration.rb
+++ b/features/support/context/service_readiness_configuration.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'rbconfig'
+
+module Nonnative
+  module Features
+    module Context
+      module ServiceReadinessConfiguration
+        SERVICE_TCP_READINESS = [
+          {
+            name: 'service_1',
+            host: '127.0.0.1',
+            port: 20_006,
+            readiness: [{ kind: 'tcp', host: '127.0.0.1', port: 30_000 }],
+            proxy: {
+              kind: 'fault_injection',
+              host: '127.0.0.1',
+              port: 30_000,
+              log: 'test/reports/proxy_service_1.log',
+              wait: 0.1,
+              options: { delay: 0.1 }
+            }
+          }
+        ].freeze
+
+        MISSING_TCP_READINESS = [
+          {
+            name: 'service_1',
+            host: '127.0.0.1',
+            port: 20_006,
+            timeout: 0.1,
+            readiness: [{ kind: 'tcp', host: '127.0.0.1', port: 30_001 }],
+            proxy: {
+              kind: 'fault_injection',
+              host: '127.0.0.1',
+              port: 30_000,
+              log: 'test/reports/proxy_service_1.log',
+              wait: 0.1,
+              options: { delay: 0.1 }
+            }
+          }
+        ].freeze
+
+        def configure_services_with_tcp_readiness_programmatically
+          configure_with_defaults do |config|
+            SERVICE_TCP_READINESS.each { |definition| add_service(config, definition) }
+          end
+        end
+
+        def configure_services_with_missing_tcp_readiness_programmatically
+          configure_with_defaults do |config|
+            MISSING_TCP_READINESS.each { |definition| add_service(config, definition) }
+          end
+        end
+
+        def configure_process_with_missing_service_tcp_readiness_programmatically
+          @service_readiness_process_output = 'test/reports/service_readiness_process_output'
+          FileUtils.rm_f(@service_readiness_process_output)
+
+          configure_with_defaults do |config|
+            MISSING_TCP_READINESS.each { |definition| add_service(config, definition) }
+            add_process(config, service_readiness_process)
+          end
+        end
+
+        private
+
+        def service_readiness_process
+          {
+            name: 'service_readiness_process',
+            command: -> { [RbConfig.ruby, 'features/support/bin/start', '12418', @service_readiness_process_output] },
+            timeout: 2,
+            wait: 0.1,
+            host: '127.0.0.1',
+            ports: [12_418],
+            log: 'test/reports/12_418.log',
+            signal: 'INT'
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -6,7 +6,7 @@
 # It can:
 #
 # - start external processes and in-process servers
-# - wait for readiness via port checks and optional process HTTP/gRPC readiness
+# - wait for readiness via port checks, optional process HTTP/gRPC readiness, and optional service TCP readiness
 # - optionally run fault-injection proxies in front of services
 #
 # The public entry points are exposed as module-level methods on {Nonnative}.
@@ -76,6 +76,7 @@ require 'nonnative/configuration_file'
 require 'nonnative/configuration'
 require 'nonnative/configuration_runner'
 require 'nonnative/configuration_readiness'
+require 'nonnative/configuration_service_readiness'
 require 'nonnative/configuration_process'
 require 'nonnative/configuration_server'
 require 'nonnative/configuration_service'
@@ -86,6 +87,7 @@ require 'nonnative/server'
 require 'nonnative/service'
 require 'nonnative/pool'
 require 'nonnative/http_client'
+require 'nonnative/tcp_probe'
 require 'nonnative/http_probe'
 require 'nonnative/grpc_health'
 require 'nonnative/grpc_probe'

--- a/lib/nonnative/configuration.rb
+++ b/lib/nonnative/configuration.rb
@@ -177,11 +177,11 @@ module Nonnative
     def add_services(cfg)
       services = cfg.services || []
       services.each do |loaded_service|
-        reject_readiness(loaded_service, 'services')
-
         service do |service_config|
           service_config.name = loaded_service.name
           service_config.host = loaded_service.host if loaded_service.host
+          service_config.timeout = loaded_service.timeout if loaded_service.timeout
+          service_config.readiness = loaded_service.readiness if loaded_service.readiness
           assign_service_port(service_config, loaded_service)
 
           assign_proxy(service_config, loaded_service.proxy)

--- a/lib/nonnative/configuration_service.rb
+++ b/lib/nonnative/configuration_service.rb
@@ -14,10 +14,16 @@ module Nonnative
     # @return [Integer] client-facing port used by the service proxy
     attr_accessor :port
 
+    # @return [Numeric] readiness timeout (seconds) used when waiting for service readiness
+    attr_accessor :timeout
+
     # Proxy configuration for this service.
     #
     # @return [Nonnative::ConfigurationProxy]
     attr_reader :proxy
+
+    # @return [Array<Nonnative::ConfigurationServiceReadiness>] optional service readiness checks
+    attr_reader :readiness
 
     # Creates a service configuration with defaults.
     #
@@ -26,7 +32,17 @@ module Nonnative
       super
 
       self.port = 0
+      self.timeout = DEFAULT_TIMEOUT
+      @readiness = []
       @proxy = Nonnative::ConfigurationProxy.new
+    end
+
+    # Sets optional service readiness checks.
+    #
+    # @param value [Array<Hash, #to_h>, nil] readiness checks with required `kind`, `host`, and `port`
+    # @return [void]
+    def readiness=(value)
+      @readiness = value.nil? ? [] : build_readiness(value)
     end
 
     # Sets proxy configuration using a hash-like value.
@@ -66,6 +82,14 @@ module Nonnative
     # @raise [ArgumentError] when plural service ports are assigned
     def ports=(_value)
       raise ArgumentError, "Use 'port' instead of 'ports' for service '#{name}'"
+    end
+
+    private
+
+    def build_readiness(value)
+      raise ArgumentError, 'Service readiness must be a list of checks' unless value.is_a?(Array)
+
+      value.map { |check| Nonnative::ConfigurationServiceReadiness.new(check) }
     end
   end
 end

--- a/lib/nonnative/configuration_service_readiness.rb
+++ b/lib/nonnative/configuration_service_readiness.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Nonnative
+  # Service readiness check configuration.
+  #
+  # Service readiness is for externally managed dependencies. The TCP target should be the dependency
+  # endpoint that must be reachable before managed servers and processes start.
+  class ConfigurationServiceReadiness
+    KINDS = %w[tcp].freeze
+
+    # @return [String] readiness check kind
+    attr_reader :kind
+
+    # @return [String] readiness target host
+    attr_reader :host
+
+    # @return [Integer] readiness target port
+    attr_reader :port
+
+    # @param value [Hash, #to_h] readiness check attributes
+    # @return [void]
+    def initialize(value)
+      attributes = value.to_h.transform_keys(&:to_sym)
+
+      @kind = attributes[:kind]&.to_s
+      @host = attributes[:host]
+      @port = attributes[:port]
+
+      validate!
+    end
+
+    # Returns whether this is a TCP readiness check.
+    #
+    # @return [Boolean]
+    def tcp?
+      kind == 'tcp'
+    end
+
+    private
+
+    def validate!
+      raise ArgumentError, "Service readiness requires 'kind'" if kind.nil?
+      raise ArgumentError, "Service readiness kind must be one of: #{KINDS.join(', ')}" unless KINDS.include?(kind)
+      raise ArgumentError, "Service readiness requires 'host'" if host.nil?
+      raise ArgumentError, "Service readiness requires 'port'" if port.nil?
+    end
+  end
+end

--- a/lib/nonnative/pool.rb
+++ b/lib/nonnative/pool.rb
@@ -25,7 +25,8 @@ module Nonnative
 
     # Starts all configured runners and yields results for each process/server.
     #
-    # Services are started first (proxy-only), then servers and processes are started and checked for readiness.
+    # Services are started first (proxy-only) and checked for opt-in readiness, then servers and processes are
+    # started and checked for readiness.
     #
     # @yieldparam name [String, nil] runner name
     # @yieldparam values [Object] runner-specific return value from `start` (e.g. `[pid, running]` for processes)
@@ -36,6 +37,10 @@ module Nonnative
       errors = []
 
       errors.concat(service_lifecycle(services, :start, :start))
+      service_readiness_errors = check_service_readiness(services)
+      errors.concat(service_readiness_errors)
+      return errors if service_readiness_errors.any?
+
       [servers, processes].each { |runners| errors.concat(run_lifecycle_checks(runners, :start, :open?, :start, &)) }
 
       errors
@@ -180,6 +185,15 @@ module Nonnative
       end
     end
 
+    def check_service_readiness(all)
+      all.each_with_object([]) do |service, errors|
+        next unless service.respond_to?(:readiness)
+
+        checks = service.readiness.map { |readiness| Nonnative::TCPProbe.new(readiness, timeout: service.timeout) }
+        errors << service_readiness_error(service, checks) unless checks.all?(&:ready?)
+      end
+    end
+
     def run_lifecycle_checks(runners, lifecycle_method, port_method, action, &)
       checks = []
       errors = []
@@ -218,6 +232,10 @@ module Nonnative
     def port_error(action, type, error)
       check = action == :start ? 'readiness' : 'shutdown'
       "#{check.capitalize} check failed for #{runner_name(type)}: #{error.class} - #{error.message}"
+    end
+
+    def service_readiness_error(service, checks)
+      "Started #{runner_name(service)}, though did not respond in time for readiness: #{checks.map(&:endpoint).join(', ')}"
     end
 
     def runner_name(type)

--- a/lib/nonnative/service.rb
+++ b/lib/nonnative/service.rb
@@ -24,6 +24,20 @@ module Nonnative
       @proxy = Nonnative::ProxyFactory.create(service)
     end
 
+    # Returns configured service readiness checks.
+    #
+    # @return [Array<Nonnative::ConfigurationServiceReadiness>]
+    def readiness
+      service.readiness
+    end
+
+    # Returns the configured service readiness timeout.
+    #
+    # @return [Numeric]
+    def timeout
+      service.timeout
+    end
+
     # Starts the configured proxy (if any).
     #
     # @return [void]

--- a/lib/nonnative/tcp_probe.rb
+++ b/lib/nonnative/tcp_probe.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Nonnative
+  # Probes a TCP readiness endpoint.
+  class TCPProbe
+    Target = Struct.new(:host, :timeout, keyword_init: true)
+
+    # @param readiness [#host, #port] TCP readiness attributes
+    # @param timeout [Numeric] maximum time to wait for the TCP endpoint
+    def initialize(readiness, timeout:)
+      @port = Nonnative::Port.new(Target.new(host: readiness.host, timeout:), readiness.port)
+    end
+
+    # Returns whether the TCP endpoint becomes connectable before the timeout elapses.
+    #
+    # @return [Boolean]
+    def ready?
+      port.open?
+    end
+
+    # Returns the checked endpoint for lifecycle diagnostics.
+    #
+    # @return [String]
+    def endpoint
+      port.endpoint
+    end
+
+    private
+
+    attr_reader :port
+  end
+end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.12.0'
+  VERSION = '3.13.0'
 end


### PR DESCRIPTION
## What

- Add opt-in service TCP readiness checks with explicit `kind: tcp`, `host`, and `port` configuration for programmatic and YAML service entries.
- Check configured service readiness after service/proxy startup and before managed servers/processes start, with startup errors reporting the readiness endpoint that did not become reachable.
- Document service TCP readiness, including the proxied dependency rule that readiness should target the upstream dependency endpoint rather than the client-facing proxy listener.
- Bump the gem version to `3.13.0`.

## Why

- Downstream suites that proxy external dependencies need a clear way to fail fast when the backing dependency is unavailable, instead of discovering that later through application readiness timeouts or request failures.
- Explicit TCP readiness lets services such as proxied Postgres verify the upstream dependency is reachable before the system under test starts, while leaving existing service behavior unchanged when readiness is not configured.

## Testing

- `make lint` - passed
- `make sec` - passed
- `make features` - passed
- `make benchmarks` - passed
- Added Cucumber coverage for service TCP readiness YAML mapping, invalid service readiness configuration, startup success, startup failure diagnostics, and preventing managed processes from starting after service readiness fails.
