### PR TITLE
docs(agents): record rejected feature decisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,17 @@ of dependencies.
   Cucumber helpers. Do not flag their absence from `lib/nonnative/cucumber.rb`
   as a feature gap unless downstream usage evidence exists or the task is
   explicitly about expanding public lifecycle assertion steps.
+- Liveness, readiness, and metrics endpoint assertion steps in
+  `features/step_definitions/servers_steps.rb` are repository-local Cucumber
+  helpers for testing nonnative's own framework assumptions. Do not flag their
+  absence from `lib/nonnative/cucumber.rb` as a feature gap unless downstream
+  usage evidence exists or the task is explicitly about expanding public
+  observability assertion steps.
+- `Nonnative::Configuration` intentionally exposes `process_by_name` without
+  matching `server_by_name` or `service_by_name` helpers. Do not flag missing
+  server/service configuration lookup helpers as a feature gap unless downstream
+  usage evidence exists or the task is explicitly about changing the
+  pre-start configuration lookup API.
 
 ## Runtime Model
 


### PR DESCRIPTION
## What

- Add AGENTS guidance for two rejected feature candidates: public observability endpoint assertion steps and server/service configuration lookup helpers.
- Clarify that both ideas should stay out of the feature-gap queue unless downstream usage evidence appears or the task explicitly changes the public surface.

## Why

- Preserve the product decisions from the feature-gap review so future agents do not re-raise local framework assumptions or API-symmetry ideas as accepted package-consumer gaps.
- Keep the public Cucumber and configuration API boundaries tied to demonstrated consumer need rather than repository-local convenience.

## Testing

- `make lint` - passed
- Reviewed the changed AGENTS guidance against the referenced local step definitions and configuration lookup surfaces.
