### PR TITLE
feat(invalid_data): corrupt delimiter-only responses without a frozen-string error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.15.0)
+    nonnative (3.16.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/features/services.feature
+++ b/features/services.feature
@@ -102,6 +102,16 @@ Feature: Service proxies
     And I receive data from the service
     Then I should receive an invalid service response that is not "test"
 
+  @reset
+  Scenario: Invalid proxy data corrupts a delimiter-only service response
+    Given I configure the system programmatically with services
+    And I start the system
+    And I set the proxy for service 'service_1' to 'invalid_data'
+    When I connect to the service
+    And I send "" to the service
+    And I receive data from the service
+    Then I should receive an invalid service response that is not ""
+
   Scenario: Looking up a missing service proxy fails
     Given I configure the system programmatically with services
     And I start the system

--- a/lib/nonnative/invalid_data_socket_pair.rb
+++ b/lib/nonnative/invalid_data_socket_pair.rb
@@ -46,7 +46,8 @@ module Nonnative
       payload = data.delete_suffix(delimiter)
 
       # A delimiter-only response still needs one byte we can corrupt without losing the terminator.
-      payload = "\0" if payload.empty?
+      # Use a mutable buffer: the frozen string literal cannot be mutated by #setbyte below.
+      payload = +"\0" if payload.empty?
 
       # Flip the first byte so the payload is definitely wrong without mangling the whole
       # response structure and turning an invalid response into a timeout.

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.15.0'
+  VERSION = '3.16.0'
 end


### PR DESCRIPTION
## What

- Fix `Nonnative::InvalidDataSocketPair#corrupt` so the `invalid_data` fault-injection proxy corrupts delimiter-only or empty upstream responses (a bare `\n`, `\r\n`, `\r`, or empty payload) instead of raising `FrozenError`.
- The one-byte placeholder is now a mutable buffer, so the byte flip succeeds and the client receives corrupted-but-delimited bytes, matching the behaviour the surrounding comment already promised.
- Add a Cucumber regression scenario that drives a delimiter-only response through the `invalid_data` proxy.
- No public API change; behaviour for non-empty responses is unchanged.

## Why

- Under `# frozen_string_literal: true` the placeholder `"\0"` was frozen, so `setbyte` raised `FrozenError` whenever a response was empty after stripping its line ending. `FaultInjectionProxy#connect` swallowed the error and closed the client socket, so the injected fault silently became a connection teardown — the opposite of the intended "return corrupted data" behaviour, and exactly the delimiter-only case the code claimed to handle.
- Line-oriented protocols routinely emit bare line endings (blank lines, header separators, keepalive newlines), so downstream fault-injection suites could see misleading connection drops instead of corrupted data.

## Testing

- `make features` - passed (105 scenarios, 354 steps; the new scenario fails before the fix with "expected nil to be a kind of String" and passes after)
- `make lint` - passed (88 files, no offenses)
- `make sec` - passed (Gemfile.lock, 0 vulnerabilities)
- New scenario "Invalid proxy data corrupts a delimiter-only service response" covers the previously-uncovered empty/delimiter-only corruption path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
