### PR TITLE
feat(pool): report service readiness probe errors instead of an opaque start failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.16.0)
+    nonnative (3.17.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/features/services.feature
+++ b/features/services.feature
@@ -39,6 +39,11 @@ Feature: Service proxies
     Then starting the system should raise an error containing "readiness: 127.0.0.1:30001"
     And the service readiness process side effect should not happen
 
+  Scenario: Service TCP readiness resolution failures are reported during startup
+    Given I configure the system programmatically with unresolvable service TCP readiness
+    When I attempt to start the system
+    Then starting the system should raise an error containing "Readiness check failed for runner 'service_1': Socket::ResolutionError"
+
   @reset
   Scenario: Services can run without proxies
     Given I configure the system programmatically with services without proxies

--- a/features/step_definitions/services_steps.rb
+++ b/features/step_definitions/services_steps.rb
@@ -24,6 +24,10 @@ Given('I configure the system programmatically with a process and missing servic
   configure_process_with_missing_service_tcp_readiness_programmatically
 end
 
+Given('I configure the system programmatically with unresolvable service TCP readiness') do
+  configure_services_with_unresolvable_tcp_readiness_programmatically
+end
+
 Given('I configure the system through configuration with services') do
   load_configuration('features/configs/services.yml')
 end

--- a/features/support/context/service_readiness_configuration.rb
+++ b/features/support/context/service_readiness_configuration.rb
@@ -48,9 +48,33 @@ module Nonnative
           end
         end
 
+        UNRESOLVABLE_TCP_READINESS = [
+          {
+            name: 'service_1',
+            host: '127.0.0.1',
+            port: 20_006,
+            timeout: 0.1,
+            readiness: [{ kind: 'tcp', host: 'nonnative.invalid', port: 30_001 }],
+            proxy: {
+              kind: 'fault_injection',
+              host: '127.0.0.1',
+              port: 30_000,
+              log: 'test/reports/proxy_service_1.log',
+              wait: 0.1,
+              options: { delay: 0.1 }
+            }
+          }
+        ].freeze
+
         def configure_services_with_missing_tcp_readiness_programmatically
           configure_with_defaults do |config|
             MISSING_TCP_READINESS.each { |definition| add_service(config, definition) }
+          end
+        end
+
+        def configure_services_with_unresolvable_tcp_readiness_programmatically
+          configure_with_defaults do |config|
+            UNRESOLVABLE_TCP_READINESS.each { |definition| add_service(config, definition) }
           end
         end
 

--- a/lib/nonnative/pool.rb
+++ b/lib/nonnative/pool.rb
@@ -191,6 +191,8 @@ module Nonnative
 
         checks = service.readiness.map { |readiness| Nonnative::TCPProbe.new(readiness, timeout: service.timeout) }
         errors << service_readiness_error(service, checks) unless checks.all?(&:ready?)
+      rescue StandardError => e
+        errors << port_error(:start, service, e)
       end
     end
 

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.16.0'
+  VERSION = '3.17.0'
 end


### PR DESCRIPTION
## What

- Guard service readiness in `Nonnative::Pool#check_service_readiness` so a probe exception (e.g. `Socket::ResolutionError` from an unresolvable host, or `Errno::ETIMEDOUT` from a firewalled one) is reported through the existing `port_error` path — the same structured `"Readiness check failed for runner '<name>': <class> - <message>"` used for process/server readiness — instead of escaping as an opaque `"Start failed with …"` plus an unexpected full rollback.
- A readiness check that simply times out still reports the existing `"did not respond in time for readiness: host:port"`.
- Add a Cucumber regression scenario exercising an unresolvable readiness host.
- No public API change.

## Why

- `check_port` already wraps process/server readiness in `rescue StandardError` and reports a structured per-runner error, but `check_service_readiness` ran `checks.all?(&:ready?)` unguarded. `Port#open?` only rescues `Errno::ECONNREFUSED`/`EHOSTUNREACH`, so any other socket error escaped `Timeout#perform` and `Pool#start`, surfacing as a confusing top-level `Nonnative::StartError` ("Start failed with Socket::ResolutionError: …") and triggering rollback. Operators debugging a mistyped or unreachable dependency host got no actionable per-service message. This brings service readiness in line with the process/server contract.

## Testing

- `make features` - passed (106 scenarios, 357 steps; the new scenario fails before the fix with the opaque "Start failed with Socket::ResolutionError" message and passes after with the structured "Readiness check failed for runner 'service_1': Socket::ResolutionError")
- `make lint` - passed (88 files, no offenses)
- `make sec` - not re-run; unaffected (Ruby-only change, no Gemfile/dependency changes since it last passed clean)
- New scenario "Service TCP readiness resolution failures are reported during startup" uses an unresolvable host (`nonnative.invalid`) to cover the previously-unguarded probe-exception path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
