### PR TITLE
docs(readme): document the token generation api

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ of dependencies.
 Public entry point: `lib/nonnative.rb`.
 
 Main API: `configure`, `start`, `stop`, `clear`, `reset`, `pool`,
-`go_argv`, `go_command`.
+`go_argv`, `go_command`, `token`.
 
 Configuration is `Nonnative::Configuration`, built with
 `config.process`, `config.server`, `config.service`, or
@@ -126,6 +126,16 @@ Runners:
 `Nonnative::Pool` starts services first, then servers/processes, and stops in
 reverse. Readiness and shutdown checks are TCP-only via
 `Nonnative::Port#open?` and `#closed?`.
+
+Token generation: `Nonnative.token(kind:, issuer:, key:, private_key:, expiration:)`
+returns a `Nonnative::Token` whose `generate(aud:, sub:)` produces a signed token for
+authenticating against services under test; it feeds `Nonnative::Header.auth_bearer`.
+Kinds are `jwt` (EdDSA, `kid` header), `paseto` (v4.public, `kid` footer), and `ssh`
+(go-service style raw-Ed25519 `base64(claims).base64(signature)`). All Ed25519 and
+generation-only. `jwt`/`paseto` take a PKCS#8 PEM key; `ssh` takes an OpenSSH-format
+key. PASETO needs system libsodium (via `rbnacl`), required lazily so `require
+'nonnative'` works without it until a PASETO token is generated.
+`Nonnative::Token.http_audience` / `grpc_audience` build the endpoint-scoped `aud`.
 
 ## Cucumber Surface
 
@@ -192,6 +202,7 @@ Limitations:
 - Readiness/timeouts: `lib/nonnative/port.rb`, `lib/nonnative/timeout.rb`
 - Process lifecycle: `lib/nonnative/process.rb`
 - Go executable command/argv building: `lib/nonnative/go_executable.rb`
+- Token generation: `lib/nonnative/token.rb`, `lib/nonnative/jwt_token.rb`, `lib/nonnative/paseto_token.rb`, `lib/nonnative/ssh_token.rb`, `lib/nonnative/ed25519_key.rb`
 - Proxies: `lib/nonnative/fault_injection_proxy.rb`, `lib/nonnative/socket_pair_factory.rb`
 - Cucumber: `lib/nonnative/cucumber.rb`, `lib/nonnative/startup.rb`, `features/support/env.rb`
 - Config loading: `lib/nonnative/configuration.rb`, `lib/nonnative/configuration_file.rb`, `lib/nonnative/configuration_runner.rb`, `lib/nonnative/configuration_proxy.rb`

--- a/README.md
+++ b/README.md
@@ -180,6 +180,37 @@ health = Nonnative.grpc_health(
 expect(health.serving?).to eq(true)
 ```
 
+### 🔑 Tokens
+
+`Nonnative.token` builds a signer for authenticating requests against a service under test. You pass the signing parameters directly (parsed from your own configuration); it is not coupled to any service's config format. The generated string is ready for `Nonnative::Header.auth_bearer`.
+
+```ruby
+token = Nonnative.token(
+  kind: 'jwt',
+  issuer: 'iss',
+  key: 'key-1',
+  private_key: 'config/ed25519.pem',
+  expiration: 3600
+)
+
+headers = Nonnative::Header.auth_bearer(
+  token.generate(aud: Nonnative::Token.http_audience('GET', '/v1/things'), sub: 'user-1')
+)
+```
+
+Supported `kind` values (all Ed25519, generation only):
+
+- `jwt`: EdDSA JWT with the key id in the `kid` header. `private_key` is a PKCS#8 PEM file.
+- `paseto`: PASETO v4.public with the key id in a `{"kid":"..."}` footer. `private_key` is a PKCS#8 PEM file. Requires system **libsodium** (via `rbnacl`); it loads lazily, so `require 'nonnative'` works without libsodium until you generate a PASETO token.
+- `ssh`: go-service style `base64(claims).base64(signature)` with a raw Ed25519 signature over `v1` claims. `private_key` is an **OpenSSH-format** key. `issuer` and `sub` are ignored (the subject is the key id).
+
+The audience is endpoint-scoped; build it with the helpers:
+
+```ruby
+Nonnative::Token.http_audience('GET', '/v1/things')        # => "GET /v1/things"
+Nonnative::Token.grpc_audience('/health.v1.Health/Check')  # => "/health.v1.Health/Check"
+```
+
 ### 🔁 Lifecycle strategies (Cucumber integration)
 
 Nonnative ships Cucumber hooks (when loaded) that support these tags/strategies:


### PR DESCRIPTION
## What

- Add a "Tokens" section to the README documenting `Nonnative.token`: usage feeding `Nonnative::Header.auth_bearer`, the `jwt`/`paseto`/`ssh` kinds and their key formats (PKCS#8 PEM for JWT/PASETO, OpenSSH for SSH), the libsodium prerequisite for PASETO, and the `http_audience`/`grpc_audience` helpers.
- Update `AGENTS.md`: add `token` to the `Main API` list, add a Runtime Model note describing the token surface, and add a `Look First` pointer to the token files.

## Why

- The token generation feature shipped without user- or agent-facing documentation: the README documented every other public capability but not tokens, and `AGENTS.md`'s `Main API` list omitted `token`. This closes that gap so consumers know how to use it — including that PASETO needs system libsodium and SSH needs an OpenSSH-format key — and future agents can see the surface.

## Testing

- Documentation-only change; there is no markdown linter in this repository.
- Verified the documented README example executes end to end and the `http_audience`/`grpc_audience` outputs match their inline comments (`"GET /v1/things"`, `"/health.v1.Health/Check"`), and that `Header.auth_bearer` returns a `Bearer` authorization header.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
