### PR TITLE
feat(token): add optional time-claim overrides for negative auth tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,15 @@ of dependencies.
   unless the task is explicitly about changing the `Nonnative::Service`
   readiness model. HTTP/gRPC readiness belongs to managed processes, where the
   user explicitly models the application health endpoints.
+- Managed-process readiness intentionally supports only TCP-port-open plus the
+  optional `http`/`grpc` health probes in `Nonnative::ConfigurationReadiness`.
+  A log-line/log-message readiness kind (`kind: 'log'`) is intentionally not
+  supported: systems tested with nonnative are typically deployed in container
+  environments where readiness is modeled through probes that are usually
+  HTTP-based, so the application already exposes an HTTP (or gRPC) health
+  endpoint the existing readiness kinds cover. Do not flag the absence of a
+  log-message readiness kind as a feature gap unless the task is explicitly
+  about changing the process readiness model.
 - Process runners intentionally inherit the parent working directory. Nonnative
   is normally run from the test folder that owns `test/nonnative.yml`, relative
   config paths, logs, and reports. Do not flag missing process cwd/chdir support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.19.0)
+    nonnative (3.20.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -211,6 +211,15 @@ Nonnative::Token.http_audience('GET', '/v1/things')        # => "GET /v1/things"
 Nonnative::Token.grpc_audience('/health.v1.Health/Check')  # => "/health.v1.Health/Check"
 ```
 
+By default the time claims are pinned to the current time (`iat`/`nbf` at now, `exp` at `now + expiration`). To write negative auth tests, `generate` accepts optional absolute `Time` overrides — `issued_at`, `not_before`, and `expires_at` — for minting not-yet-valid or clock-skewed tokens:
+
+```ruby
+# a token that is not valid until an hour from now
+token.generate(aud: 'GET /v1/things', sub: 'user-1', not_before: Time.now + 3600)
+```
+
+`ssh` tokens have no `nbf` claim, so passing `not_before` for the `ssh` kind raises `ArgumentError`.
+
 ### 🔁 Lifecycle strategies (Cucumber integration)
 
 Nonnative ships Cucumber hooks (when loaded) that support these tags/strategies:

--- a/features/step_definitions/token_steps.rb
+++ b/features/step_definitions/token_steps.rb
@@ -22,10 +22,33 @@ When('I generate a {string} token for the {string} method as {string}') do |kind
   generate_token(kind, Nonnative::Token.grpc_audience(full_method), sub)
 end
 
+When('I generate a {string} token with:') do |kind, table|
+  generate_token_with(kind, **token_options(table))
+end
+
+When('I try to generate a {string} token with:') do |kind, table|
+  generate_token_with(kind, **token_options(table))
+rescue ArgumentError => e
+  @error = e
+end
+
 Then('the token should be verifiable with:') do |table|
   claims, kid = decoded_token(@kind, @token, @signing_material)
 
   table.rows_hash.each do |field, expected|
     expect(field == 'kid' ? kid : claims[field]).to eq(expected)
   end
+end
+
+Then('the token time claims should be:') do |table|
+  claims = token_time_claims(@kind, @token, @signing_material)
+
+  table.rows_hash.each do |field, expected|
+    expect(claims[field]).to eq(Integer(expected))
+  end
+end
+
+Then('token generation should fail with {string}') do |message|
+  expect(@error).to be_a(ArgumentError)
+  expect(@error.message).to include(message)
 end

--- a/features/support/context/token_verification.rb
+++ b/features/support/context/token_verification.rb
@@ -9,16 +9,49 @@ module Nonnative
           OpenSSL::PKey.new_raw_private_key('ED25519', SecureRandom.bytes(32)).private_to_pem
         end
 
+        # Default generation options; scenarios override or extend them through the token table.
+        TOKEN_DEFAULTS = { aud: 'GET /v1/things', sub: 'user-1' }.freeze
+
+        # Generation options whose table values are Unix seconds and become Time objects.
+        TOKEN_TIME_CLAIMS = %i[issued_at not_before expires_at].freeze
+
         def generate_token(kind, aud, sub)
+          generate_token_with(kind, aud: aud, sub: sub)
+        end
+
+        def generate_token_with(kind, **)
           @kind = kind
           @token = Nonnative.token(kind: kind, issuer: 'iss', key: 'key-1', private_key: @private_key_path, expiration: 3600)
-                            .generate(aud: aud, sub: sub)
+                            .generate(**TOKEN_DEFAULTS, **)
+        end
+
+        # Builds generate options from a Cucumber table so the generation step can be extended with
+        # new claims by adding rows. Time-claim rows are Unix seconds and become Time objects.
+        def token_options(table)
+          table.rows_hash.each_with_object({}) do |(key, value), options|
+            name = key.to_sym
+            options[name] = TOKEN_TIME_CLAIMS.include?(name) ? Time.at(Integer(value)) : value
+          end
+        end
+
+        # Returns the token's time claims normalised to Unix seconds, keyed by claim name. Absent
+        # claims (for example ssh has no nbf) are omitted.
+        def token_time_claims(kind, token, material)
+          claims, = decoded_token(kind, token, material)
+
+          %w[iat nbf exp].each_with_object({}) do |field, result|
+            value = claims[field]
+            result[field] = time_claim_seconds(kind, value) unless value.nil?
+          end
         end
 
         def write_key_file(content)
           file = Tempfile.new(['ed25519', '.pem'])
           file.write(content)
           file.close
+          # Keep a reference for the lifetime of the scenario; otherwise the Tempfile can be
+          # garbage-collected and its finalizer unlinks the file before the key is read.
+          (@key_files ||= []) << file
 
           file.path
         end
@@ -31,6 +64,14 @@ module Nonnative
           path
         end
 
+        def time_claim_seconds(kind, value)
+          case kind
+          when 'paseto' then Time.iso8601(value).to_i
+          when 'ssh' then value / 1_000_000_000
+          else value
+          end
+        end
+
         def decoded_token(kind, token, material)
           case kind
           when 'jwt' then decoded_jwt(token, material)
@@ -41,7 +82,10 @@ module Nonnative
 
         def decoded_jwt(token, pem)
           verify_key = Ed25519::SigningKey.new(OpenSSL::PKey.read(pem).raw_private_key).verify_key
-          payload, header = JWT.decode(token, verify_key, true, algorithm: 'EdDSA')
+          # Verify the signature but skip time-claim validation so deliberately not-yet-valid or
+          # expired tokens (generated with time overrides) can be decoded and inspected.
+          payload, header = JWT.decode(token, verify_key, true,
+                                       algorithm: 'EdDSA', verify_expiration: false, verify_not_before: false)
 
           [payload, header['kid']]
         end

--- a/features/token.feature
+++ b/features/token.feature
@@ -40,3 +40,40 @@ Feature: Token
     When I generate a "jwt" token for the "/health.v1.Health/Check" method as "user-1"
     Then the token should be verifiable with:
       | aud | /health.v1.Health/Check |
+
+  Scenario: Generate a not-yet-valid JWT with independent time claims
+    Given an Ed25519 private key
+    When I generate a "jwt" token with:
+      | issued_at  | 4102444800 |
+      | not_before | 4102448400 |
+      | expires_at | 4102452000 |
+    Then the token time claims should be:
+      | iat | 4102444800 |
+      | nbf | 4102448400 |
+      | exp | 4102452000 |
+
+  Scenario: Generate a not-yet-valid PASETO with independent time claims
+    Given an Ed25519 private key
+    When I generate a "paseto" token with:
+      | issued_at  | 4102444800 |
+      | not_before | 4102448400 |
+      | expires_at | 4102452000 |
+    Then the token time claims should be:
+      | iat | 4102444800 |
+      | nbf | 4102448400 |
+      | exp | 4102452000 |
+
+  Scenario: Generate an SSH token with independent time claims
+    Given an OpenSSH Ed25519 private key
+    When I generate a "ssh" token with:
+      | issued_at  | 4102444800 |
+      | expires_at | 4102452000 |
+    Then the token time claims should be:
+      | iat | 4102444800 |
+      | exp | 4102452000 |
+
+  Scenario: SSH tokens reject a not-before override
+    Given an OpenSSH Ed25519 private key
+    When I try to generate a "ssh" token with:
+      | not_before | 4102448400 |
+    Then token generation should fail with "ssh tokens do not support"

--- a/lib/nonnative/jwt_token.rb
+++ b/lib/nonnative/jwt_token.rb
@@ -27,16 +27,19 @@ module Nonnative
     #
     # @param aud [String] the `aud` claim (for example `"GET /v1/things"` or a gRPC full method)
     # @param sub [String] the `sub` claim
+    # @param issued_at [Time, nil] overrides the `iat` claim (default: now)
+    # @param not_before [Time, nil] overrides the `nbf` claim (default: `issued_at`)
+    # @param expires_at [Time, nil] overrides the `exp` claim (default: `issued_at` plus `expiration`)
     # @return [String] the signed JWT
-    def generate(aud:, sub:)
-      now = Time.now.to_i
+    def generate(aud:, sub:, issued_at: nil, not_before: nil, expires_at: nil)
+      now = issued_at || Time.now
       payload = {
         iss: @issuer,
         aud: aud,
         sub: sub,
-        iat: now,
-        nbf: now,
-        exp: now + @expiration,
+        iat: now.to_i,
+        nbf: (not_before || now).to_i,
+        exp: (expires_at || (now + @expiration)).to_i,
         jti: SecureRandom.uuid
       }
 

--- a/lib/nonnative/paseto_token.rb
+++ b/lib/nonnative/paseto_token.rb
@@ -28,18 +28,21 @@ module Nonnative
     #
     # @param aud [String] the `aud` claim (for example `"GET /v1/things"` or a gRPC full method)
     # @param sub [String] the `sub` claim
+    # @param issued_at [Time, nil] overrides the `iat` claim (default: now)
+    # @param not_before [Time, nil] overrides the `nbf` claim (default: `issued_at`)
+    # @param expires_at [Time, nil] overrides the `exp` claim (default: `issued_at` plus `expiration`)
     # @return [String] the signed PASETO token
-    def generate(aud:, sub:)
+    def generate(aud:, sub:, issued_at: nil, not_before: nil, expires_at: nil)
       load_dependencies!
 
-      now = Time.now.utc
+      now = (issued_at || Time.now).utc
       claims = {
         'iss' => @issuer,
         'aud' => aud,
         'sub' => sub,
         'iat' => now.iso8601,
-        'nbf' => now.iso8601,
-        'exp' => (now + @expiration).iso8601,
+        'nbf' => (not_before || now).utc.iso8601,
+        'exp' => (expires_at || (now + @expiration)).utc.iso8601,
         'jti' => SecureRandom.uuid
       }
 

--- a/lib/nonnative/ssh_token.rb
+++ b/lib/nonnative/ssh_token.rb
@@ -30,18 +30,25 @@ module Nonnative
 
     # Generates a signed SSH token.
     #
+    # SSH tokens carry only `iat`/`exp` (in Unix nanoseconds); there is no `nbf` claim, so
+    # `not_before` is rejected.
+    #
     # @param aud [String] the `aud` claim (for example `"GET /v1/things"` or a gRPC full method)
+    # @param issued_at [Time, nil] overrides the `iat` claim (default: now)
+    # @param expires_at [Time, nil] overrides the `exp` claim (default: `issued_at` plus `expiration`)
+    # @raise [ArgumentError] if `not_before` is given (SSH tokens have no `nbf` claim)
     # @return [String] the token, `"<base64(claims)>.<base64(signature)>"`
-    def generate(aud:, **)
-      now = Time.now
-      issued_at = (now.to_i * 1_000_000_000) + now.nsec
+    def generate(aud:, issued_at: nil, expires_at: nil, not_before: nil, **)
+      raise ArgumentError, "ssh tokens do not support 'not_before' (no nbf claim)" unless not_before.nil?
+
+      iat = nanoseconds(issued_at || Time.now)
       claims = {
         ver: TOKEN_VERSION,
         kid: @key,
         sub: @key,
         aud: aud,
-        iat: issued_at,
-        exp: issued_at + (@expiration * 1_000_000_000)
+        iat: iat,
+        exp: expires_at ? nanoseconds(expires_at) : iat + (@expiration * 1_000_000_000)
       }.to_json
 
       signature = Ed25519::SigningKey.new(seed).sign(claims)
@@ -50,6 +57,10 @@ module Nonnative
     end
 
     private
+
+    def nanoseconds(time)
+      (time.to_i * 1_000_000_000) + time.nsec
+    end
 
     def seed
       SSHData::PrivateKey.parse_openssh(File.read(@private_key)).first.sk[0, 32]

--- a/lib/nonnative/token.rb
+++ b/lib/nonnative/token.rb
@@ -54,11 +54,20 @@ module Nonnative
 
     # Generates a signed token.
     #
+    # The optional time claims default to the current time (and the constructor `expiration`), so
+    # omitting them reproduces the token's normal claims. Supply them to mint tokens with specific
+    # time claims for negative auth tests, such as a not-yet-valid (future `not_before`) or
+    # clock-skewed token. Times are absolute; the `ssh` kind has no `nbf` claim and rejects
+    # `not_before`.
+    #
     # @param aud [String] the `aud` claim
     # @param sub [String] the `sub` claim
+    # @param issued_at [Time, nil] overrides the `iat` claim (default: now)
+    # @param not_before [Time, nil] overrides the `nbf` claim (default: `issued_at`); unsupported by `ssh`
+    # @param expires_at [Time, nil] overrides the `exp` claim (default: `issued_at` plus `expiration`)
     # @return [String] the signed token
-    def generate(aud:, sub:)
-      @token.generate(aud: aud, sub: sub)
+    def generate(aud:, sub:, issued_at: nil, not_before: nil, expires_at: nil)
+      @token.generate(aud: aud, sub: sub, issued_at: issued_at, not_before: not_before, expires_at: expires_at)
     end
   end
 end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.19.0'
+  VERSION = '3.20.0'
 end


### PR DESCRIPTION
## What

- `Nonnative.token(...).generate(aud:, sub:)` now accepts optional absolute-`Time` kwargs `issued_at:`, `not_before:`, and `expires_at:` to control the `iat`/`nbf`/`exp` claims when signing. Omitting them reproduces today's exact claims for all three kinds (`jwt`, `paseto`, `ssh`) byte-for-byte.
- `ssh` tokens have no `nbf` claim, so passing `not_before` to the `ssh` kind raises `ArgumentError`.
- Additive and backward-compatible; generation-only and Ed25519-only (no verification, no new kinds/keys/dependencies).
- Fixed a latent Tempfile garbage-collection flake in the Cucumber key-file helper that could unlink the PEM before it was read (`Errno::ENOENT`); the new scenarios raised the GC pressure that surfaced it. The test JWT decoder now skips time-claim validation (still verifies the signature) so deliberately time-invalid tokens can be inspected.
- Documented the new kwargs in the README, and recorded in `AGENTS.md` the decision not to add a log-message process readiness kind (container-deployed systems use HTTP/gRPC probes the existing readiness kinds already cover).

## Why

- Test authors could previously only mint tokens pinned to `now` (plus a fixed `expiration`), so they had no way to produce a not-yet-valid (future `nbf`) or clock-skewed token to prove their service *rejects* bad credentials — a real gap for negative/adversarial auth tests against verifiers such as go-service. This adds that capability without changing the default output path.
- The Tempfile fix removes intermittent local/CI failures affecting any Ed25519-PEM scenario, making the token suite deterministic.

## Testing

- `make lint` - passed
- `make sec` - passed (0 vulnerabilities, 0 secrets)
- `make features` - passed (116 scenarios); the token feature was verified deterministic over 30 consecutive runs after the Tempfile fix
- New `@contract` scenarios cover independent `iat`/`nbf`/`exp` control per kind and the SSH `not_before` rejection.
- `make benchmarks` - not run locally (no token benchmarks; unaffected by this change); covered by CI.
- Independent adversarial review of the diff found no blocking findings; byte-for-byte default compatibility was confirmed against `HEAD`.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
