### PR TITLE
feat(fault_injection): add optional latency jitter to the delay state

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.20.0)
+    nonnative (3.21.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ Clients connect to the service `host`/`port`, while the proxy forwards traffic t
 
 - `close_all` - Closes the socket as soon as it connects.
 - `reset_peer` - Resets the socket as soon as it connects, so clients observe a TCP reset (`Errno::ECONNRESET`) rather than the graceful close performed by `close_all`.
-- `delay` - Delays traffic on the connection. Defaults to 2 seconds and can be configured through options.
+- `delay` - Delays traffic on the connection. Defaults to 2 seconds and can be configured through `options.delay`. An optional `options.jitter` (seconds) adds a random offset in `-jitter..jitter` to each delay (a negative value uses its magnitude), so clients see variable, tail-latency-like timing instead of a flat value.
 - `timeout` - Accepts the connection and stalls traffic until reset or stop closes the connection, so clients exercise their own read timeout behavior.
 - `invalid_data` - Forwards client requests unchanged, then corrupts upstream responses before they reach the client.
 

--- a/features/services.feature
+++ b/features/services.feature
@@ -97,6 +97,16 @@ Feature: Service proxies
     Then I should receive "test" from the service
 
   @reset
+  Scenario: A jittered delay proxy keeps latency within the jitter envelope
+    Given I configure the system programmatically with services with jitter
+    And I start the system
+    And I set the proxy for service 'service_1' to 'delay'
+    When I connect to the service
+    And I send "test" to the service and receive the response
+    Then I should receive "test" from the service
+    And the round trip should take between 0.2 and 1.5 seconds
+
+  @reset
   Scenario: A timed-out service proxy stalls responses
     Given I configure the system programmatically with services
     And I start the system

--- a/features/step_definitions/services_steps.rb
+++ b/features/step_definitions/services_steps.rb
@@ -12,6 +12,19 @@ Given('I configure the system programmatically with services') do
   end
 end
 
+Given('I configure the system programmatically with services with jitter') do
+  configure_with_defaults do |config|
+    add_service(
+      config,
+      name: 'service_1',
+      host: '127.0.0.1',
+      port: 20_006,
+      proxy: { kind: 'fault_injection', host: '127.0.0.1', port: 30_000, log: 'test/reports/proxy_service_1.log', wait: 0.1,
+               options: { delay: 0.2, jitter: 0.1 } }
+    )
+  end
+end
+
 Given('I configure the system programmatically with services without proxies') do
   configure_with_defaults do |config|
     add_service(config, name: 'service_1', host: '127.0.0.1', port: 30_000)
@@ -133,6 +146,13 @@ When('I receive data from the service') do
   @service_response = @service.receive
 end
 
+When('I send {string} to the service and receive the response') do |message|
+  started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  @service.write(message)
+  @service_response = @service.receive
+  @elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+end
+
 When('I receive data from the service with a {float} second timeout') do |duration|
   @service_response = Timeout.timeout(duration) { @service.receive }
 rescue Timeout::Error => e
@@ -154,6 +174,10 @@ end
 
 Then('I should receive {string} from the service') do |response|
   expect(@service_response).to eq(response)
+end
+
+Then('the round trip should take between {float} and {float} seconds') do |low, high|
+  expect(@elapsed).to be_between(low, high)
 end
 
 Then('I should receive an invalid service response that is not {string}') do |message|

--- a/lib/nonnative/delay_socket_pair.rb
+++ b/lib/nonnative/delay_socket_pair.rb
@@ -5,7 +5,11 @@ module Nonnative
   #
   # When active, reads from the socket are delayed by a configured duration before being forwarded.
   #
-  # The delay duration is controlled by `proxy.options[:delay]` and defaults to 2 seconds.
+  # The delay duration is controlled by `proxy.options[:delay]` and defaults to 2 seconds. An
+  # optional `proxy.options[:jitter]` (seconds) adds a random offset in `-jitter..jitter` to each
+  # delay so clients see variable, tail-latency-like timing instead of a flat value; a negative
+  # jitter uses its magnitude and the resulting delay is never negative. When `jitter` is absent the
+  # delay is the flat duration.
   #
   # This behavior is enabled by calling {Nonnative::FaultInjectionProxy#delay}.
   #
@@ -20,10 +24,22 @@ module Nonnative
     def read(socket)
       Nonnative.logger.info "delaying socket '#{socket.inspect}' for 'delay' pair"
 
-      duration = proxy.options[:delay] || 2
-      sleep duration
+      sleep delay_duration
 
       super
+    end
+
+    private
+
+    # The delay applied before a read, optionally jittered by `proxy.options[:jitter]`.
+    #
+    # @return [Numeric] seconds to sleep (never negative)
+    def delay_duration
+      duration = proxy.options[:delay] || 2
+      jitter = proxy.options[:jitter]&.abs
+      return duration unless jitter
+
+      [duration + rand(-jitter..jitter), 0].max
     end
   end
 end

--- a/lib/nonnative/fault_injection_proxy.rb
+++ b/lib/nonnative/fault_injection_proxy.rb
@@ -33,6 +33,8 @@ module Nonnative
   # - `wait`: sleep interval (seconds) applied after state changes
   # - `options`:
   #   - `delay`: delay duration in seconds used by {#delay}
+  #   - `jitter`: optional random offset (seconds) added in `-jitter..jitter` to each `delay` (a
+  #     negative value uses its magnitude), so clients see variable latency instead of a flat value
   #
   # @see Nonnative::Proxy
   # @see Nonnative::SocketPairFactory

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.20.0'
+  VERSION = '3.21.0'
 end


### PR DESCRIPTION
## What

- The fault-injection `delay` proxy state now honors an optional `proxy.options[:jitter]` (seconds): each delayed read sleeps `[delay + rand(-jitter..jitter), 0].max` instead of a flat `delay`, so clients under test see variable, tail-latency-like timing. When `jitter` is absent the delay is byte-identical to before, and a negative `jitter` uses its magnitude (never crashes, never negative).
- Additive: no new proxy state, no new class or dependency, and no config-schema change (`options` is a free-form hash).
- Adds a `@reset` Cucumber scenario in `features/services.feature` exercising a jittered delay, plus README and docstring updates for the new option.

## Why

- The `delay` fault could previously model only one flat latency value, so a client under test could not be exercised against jitter / tail latency (for example "500ms ± 300ms") to tune its timeouts or hedging. This adds that capability without changing the default `delay` behavior, mirroring Toxiproxy's `latency ± jitter`.

## Testing

- `make lint` - passed
- `make sec` - passed (0 vulnerabilities, 0 secrets)
- `make features` - passed (117 scenarios), including the new jittered-delay scenario; the services feature was green across repeated runs
- The jitter scenario is a bounded-envelope guard: it asserts the round trip stays within the jitter bounds and still forwards data. It does not discriminate jitter from a flat delay (a flat delay also satisfies the envelope), so it is labeled test-after, not TDD — a bounded envelope cannot fail before the jitter code exists, and proving randomness deterministically would need a seedable-RNG seam that was intentionally not added.
- Independent adversarial review found no blocking issues: backward compatibility and the envelope were confirmed against `HEAD`, and the reviewer's negative-`jitter` crash finding was fixed by clamping with `.abs`.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
