### PR TITLE
docs(agents): record metrics-parser, yaml-interpolation, and grpc-health status as non-goals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,28 @@ of dependencies.
   server/service configuration lookup helpers as a feature gap unless downstream
   usage evidence exists or the task is explicitly about changing the
   pre-start configuration lookup API.
+- `Nonnative::Observability#metrics` intentionally returns the raw Prometheus
+  exposition body. Parsing it into samples or asserting a specific metric value
+  is the caller's responsibility (use a dedicated Prometheus-parsing gem if
+  needed), matching the thin, raw-response posture of the whole observability
+  client. Do not flag the absence of a built-in Prometheus text-format parser
+  (for example `Nonnative::Metrics.parse`) as a feature gap unless the task is
+  explicitly about adding metric-value parsing to the observability client.
+- YAML configuration is intentionally loaded as pure data with no evaluation or
+  substitution: no ERB, no arbitrary object tags, and no `${VAR}` /
+  environment-variable interpolation. Values that must vary between environments
+  belong in programmatic Ruby config (`config.load_file` plus
+  `config.process`/`server`/`service`), which already has full `ENV` access. Do
+  not flag the absence of in-YAML `${VAR}` interpolation as a feature gap unless
+  the task is explicitly about adding environment-variable substitution to
+  `Nonnative::ConfigurationFile`.
+- `Nonnative::GRPCHealth#check` intentionally returns the full
+  `HealthCheckResponse`, so tests assert any serving status directly (for
+  example `check.status == :NOT_SERVING`), mirroring how the HTTP observability
+  client exposes the raw response code; `serving?` is a convenience boolean on
+  top. Do not flag the absence of a `not_serving?` / `status:` helper or a
+  streaming `Watch` wrapper as a feature gap unless the task is explicitly about
+  expanding the gRPC health assertion surface.
 
 ## Runtime Model
 


### PR DESCRIPTION
## What

- Records three previously-proposed feature gaps as intentional design choices in `AGENTS.md`, so future feature-gap passes do not re-propose settled non-goals:
  - `Observability#metrics` intentionally returns the raw Prometheus exposition body; value parsing is the caller's job (no built-in `Nonnative::Metrics.parse`).
  - YAML configuration is intentionally data-only — no ERB, no object tags, and no `${VAR}` / environment-variable interpolation; environment-varying values go through programmatic Ruby config, which already has `ENV` access.
  - `GRPCHealth#check` already returns the full `HealthCheckResponse`, so any serving status is assertable directly (mirroring the HTTP raw-response pattern); no `not_serving?` / `status:` helper or `Watch` wrapper is needed.
- Documentation only: no behaviour, API, or code change.

## Why

- Each proposal was reviewed and rejected on its merits — already covered by existing behaviour (raw responses, `check`) or contradicting a deliberate convention (data-only config loading). Capturing the rationale in `AGENTS.md` (imported by `CLAUDE.md`, loaded every session) stops agents from re-surfacing these as feature gaps.

## Testing

- None — documentation-only change to `AGENTS.md`; no code or tests are affected, and no repository lint/validation target covers this prose file (`make lint` is RuboCop over Ruby only, and passed with the Ruby tree unchanged). The three statements were verified against current source: `lib/nonnative/observability.rb`, the data-only config contract in `lib/nonnative/configuration_file.rb`, and `lib/nonnative/grpc_health.rb`.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
