### PR TITLE
build(gem): add packaging and publishing make targets, slim packaged files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 /.yardoc
 /_yardoc/
 /doc/
-/pkg/
+pkg/*
+!pkg/.keep
 ISSUES.md
 TESTS.md
 DOCS.md

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,20 @@ include bin/build/make/ruby.mak
 include bin/build/make/git.mak
 include bin/build/make/claude.mak
 include bin/build/make/codex.mak
+
+.PHONY: gem-build gem-publish clean-pkg
+
+VERSION = $(shell ruby -Ilib -e "require 'nonnative/version'; print Nonnative::VERSION")
+
+# Build the gem into `pkg/`.
+gem-build:
+	@mkdir -p pkg
+	@gem build nonnative.gemspec -o pkg/nonnative-$(VERSION).gem
+
+# Remove built gems from `pkg/`, preserving the placeholder.
+clean-pkg:
+	@find pkg -mindepth 1 -maxdepth 1 ! -name .keep -exec rm -rf {} +
+
+# Publish the gem to RubyGems; pass `otp=<code>` for MFA or omit to be prompted.
+gem-publish: gem-build
+	@gem push pkg/nonnative-$(VERSION).gem $(if $(otp),--otp $(otp))

--- a/nonnative.gemspec
+++ b/nonnative.gemspec
@@ -16,7 +16,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/alexfalkowski/nonnative'
   spec.license       = 'MIT'
   spec.files         = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").select do |f|
+      File.file?(f) && !File.symlink?(f) &&
+        (f.start_with?('lib/') || %w[LICENSE README.md].include?(f))
+    end
   end
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
## What

- Add `gem-build`, `gem-publish`, and `clean-pkg` targets to the root `Makefile`.
  `gem-build` packages into `pkg/`, `clean-pkg` clears `pkg/` while preserving its
  placeholder, and `gem-publish` rebuilds then pushes to RubyGems, taking
  `otp=<code>` for MFA (or prompting interactively when omitted).
- Restrict `spec.files` in `nonnative.gemspec` to an allowlist (`lib/**` plus
  `LICENSE` and `README.md`) and exclude symlinks/non-file entries. This drops
  previously packaged dev-only files (CI config, linters, `AGENTS.md`/`CLAUDE.md`,
  `Makefile`, `Gemfile*`, the `bin` submodule entry) and fixes the
  `.agents/skills` / `.claude/skills` symlink warnings from `gem build`.
- Ignore built gems under `pkg/` while tracking a `pkg/.keep` placeholder so the
  directory persists, mirroring the existing `test/reports/.keep` convention.
- Intentional boundaries: targets are local to this gem's root `Makefile`, not the
  shared `bin` fragments; publishing stays a manual, OTP-authenticated local step
  and is not wired into CI; each published RubyGems version is one-shot, so
  publishing again requires bumping `lib/nonnative/version.rb`.

## Why

- There was no repeatable command to build or publish the gem, and `gem build`
  emitted symlink warnings while packaging dev-only tooling and the `bin`
  submodule that consumers never need. This adds a clean, documented workflow
  (`make gem-build` then `make gem-publish otp=<code>`) and ships only the runtime
  library, shrinking the packaged gem and removing the warnings.
- Tracking `pkg/.keep` keeps the build-output directory present without committing
  artifacts, so building works on a fresh checkout.

## Testing

- `make lint` - passed (94 files, no offenses; covers the gemspec change).
- `make gem-build` - passed (produces `pkg/nonnative-3.22.0.gem`; 56 files with no
  `test/`, `vendor/`, `pkg/`, or symlink entries; rebuild is byte-identical).
- `make gem-publish` (dry-run `make -n`, with and without `otp=`) - passed;
  resolves to `gem push … --otp <code>` and `gem push …`. Not executed live, since
  a real push publishes to RubyGems.
- `make clean-pkg` - passed (removes gems, preserves `pkg/.keep`, idempotent on an
  already-clean dir).
- `bundler exec ruby -Ilib -e "require 'nonnative'"` - passed. Plain non-bundler
  require fails only because runtime gems are not on the load path, which is
  unrelated to this change (it touches no `lib/` code).
- Not run: `make features` / `make benchmarks` - this change is packaging/tooling
  only and touches no `lib/` runtime code, so the library behavior suites are out
  of scope; CI still runs them.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
