### PR TITLE
build(deps): update bin to adopt the shared claude permissions baseline

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,1 @@
+../bin/build/claude/settings.json


### PR DESCRIPTION
## What

- Bump the `bin` submodule `eea7cb2 → 7cd5c16` (origin/master), adopting the
  shared Claude Code permissions baseline (#532) and picking up the accompanying
  docs and rubocop 1.88.2 changes (#531).
- Commit the `.claude/settings.json` symlink to `bin/build/claude/settings.json`
  created by `make claude-init`, alongside the existing `.claude/skills` symlink.

## Why

- Adopt the shared permissions baseline so Claude Code sessions in this
  repository inherit the same guardrailed, low-friction autonomy maintained
  centrally in `bin`, instead of each checkout re-accumulating per-machine
  command approvals.

## Testing

- `make claude-init` - passed; `.claude/settings.json -> ../bin/build/claude/settings.json` resolves and reads `defaultMode=acceptEdits` (allow 122 / ask 42 / deny 23)
- The `bin` bump is a clean fast-forward whose delta touches only Claude Code config, docs, and `bin`'s own dev lockfile — no shared `*.mak` fragment or repository source changed, so no build/test/lint behavior is affected
- CircleCI on this PR provides full repository validation

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
