### PR TITLE
feat(http): expose patch requests to client extensions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,11 @@ of dependencies.
   not flag the absence of in-YAML `${VAR}` interpolation as a feature gap unless
   the task is explicitly about adding environment-variable substitution to
   `Nonnative::ConfigurationFile`.
+- YAML configuration intentionally does not validate unknown structural keys or
+  provide a strict configuration-lint mode. Unknown fields may be ignored while
+  syntax, safety, and supported value shapes are still validated. Do not flag
+  the absence of strict unknown-key diagnostics or config linting as a feature
+  gap unless the task is explicitly about changing YAML validation behavior.
 - `Nonnative::GRPCHealth#check` intentionally returns the full
   `HealthCheckResponse`, so tests assert any serving status directly (for
   example `check.status == :NOT_SERVING`), mirroring how the HTTP observability

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.22.0)
+    nonnative (3.23.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/features/servers.feature
+++ b/features/servers.feature
@@ -29,6 +29,12 @@ Feature: Servers
     When I send a not found message with the HTTP client to the servers
     Then I should receive an HTTP not found response
 
+  Scenario: HTTP PATCH returns not found for unknown routes
+    Given I configure the system programmatically with servers
+    And I start the system
+    When I send a not found PATCH message with the HTTP client to the servers
+    Then I should receive an HTTP not found response
+
   Scenario: gRPC servers greet clients
     Given I configure the system programmatically with servers
     And I start the system

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -46,7 +46,7 @@ When('I send a message with the HTTP client to the servers') do
   @responses = %w[http_server_1 http_server_2].flat_map do |name|
     client = http_client_for_server(name)
 
-    [client.hello_get, client.hello_post, client.hello_put, client.hello_delete]
+    [client.hello_get, client.hello_post, client.hello_put, client.hello_patch, client.hello_delete]
   end
 end
 
@@ -67,6 +67,10 @@ end
 
 When('I send a not found message with the HTTP client to the servers') do
   @response = http_client_for_server('http_server_1').not_found
+end
+
+When('I send a not found PATCH message with the HTTP client to the servers') do
+  @response = http_client_for_server('http_server_1').patch_not_found
 end
 
 When('I look up the server runner {string}') do |name|

--- a/features/support/http_client.rb
+++ b/features/support/http_client.rb
@@ -27,6 +27,20 @@ module Nonnative
         end
       end
 
+      def hello_patch
+        with_retry(1, 1) do
+          headers = Nonnative::Header.http_user_agent('test 1.0').merge({ content_type: :json, accept: :json })
+
+          patch('hello', 'Hello World!', { headers:, read_timeout: 1, open_timeout: 1 })
+        end
+      end
+
+      def patch_not_found
+        with_retry(1, 1) do
+          patch('notfound', 'Hello World!', { headers: { content_type: :json, accept: :json }, read_timeout: 1, open_timeout: 1 })
+        end
+      end
+
       def hello_delete
         with_retry(1, 1) do
           delete('hello', { headers: { content_type: :json, accept: :json }, read_timeout: 1, open_timeout: 1 })

--- a/lib/nonnative/http_client.rb
+++ b/lib/nonnative/http_client.rb
@@ -80,6 +80,18 @@ module Nonnative
       end
     end
 
+    # Performs a PATCH request.
+    #
+    # @param pathname [String] path relative to `host`
+    # @param payload [Object] request payload
+    # @param opts [Hash] RestClient request options
+    # @return [RestClient::Response, String] response for non-2xx errors, otherwise the RestClient result
+    def patch(pathname, payload, opts = {})
+      with_exception do
+        resource(pathname, opts).patch(payload)
+      end
+    end
+
     # Creates a RestClient resource for a relative path.
     #
     # @param pathname [String] path relative to `host`

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.22.0'
+  VERSION = '3.23.0'
 end


### PR DESCRIPTION
## What

- Add a protected PATCH helper to the shared HTTP client extension surface with the same payload, options, response, and exception behavior as the existing verbs.
- Extend the existing HTTP Cucumber fixture with successful and unknown-route PATCH coverage.
- Record the intentional YAML policy that unknown structural keys remain permissive and no strict configuration-lint mode is provided.

## Why

- Downstream HTTP client subclasses currently have to duplicate Nonnative's private exception wrapper to issue routine PATCH requests. The additive helper gives package consumers a supported extension point without changing existing verb behavior or adding dependencies.
- The focused success and 404 scenarios protect both normal PATCH dispatch and the established non-2xx response contract.
- The AGENTS policy preserves the deliberate configuration boundary after FEATURE-2 was removed.

## Testing

- `make features feature=features/servers.feature` - passed; 14 scenarios and 53 steps.
- `make features` - passed; 119 scenarios and 408 steps.
- `make benchmarks` - passed; 7 scenarios and 27 steps.
- `make lint` - passed; 94 files inspected with no offenses.
- `make sec` - passed; zero vulnerabilities reported.
- `git diff --check` - passed.

AI-assisted-by: [Codex](https://openai.com/codex/)
