### PR TITLE
feat(transport): compose in-process HTTP and gRPC services

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.23.0)
+    nonnative (3.24.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -465,6 +465,30 @@ module Nonnative
 end
 ```
 
+To run multiple Rack services on one managed port, pass a non-empty mount map. Each key must start
+with `/`, and the mounted application receives the remaining `PATH_INFO`:
+
+```ruby
+module Nonnative
+  module Features
+    class HealthService < Nonnative::HTTPService
+      get '/' do
+        'ok'
+      end
+    end
+
+    class HTTPServer < Nonnative::HTTPServer
+      def initialize(service)
+        super({ '/api' => HelloService.new, '/health' => HealthService.new }, service)
+      end
+    end
+  end
+end
+```
+
+The existing single-service form remains supported. Nonnative converts a mount map to a
+`Rack::URLMap` and keeps one server lifecycle and port. An empty mount map raises `ArgumentError`.
+
 Set it up programmatically:
 
 ```ruby
@@ -602,6 +626,30 @@ module Nonnative
   end
 end
 ```
+
+To serve multiple gRPC services on one managed port, pass a non-empty array of handler classes or
+instances:
+
+```ruby
+module Nonnative
+  module Features
+    class HealthService < Grpc::Health::V1::Health::Service
+      def check(_request, _call)
+        Grpc::Health::V1::HealthCheckResponse.new(status: :SERVING)
+      end
+    end
+
+    class GRPCServer < Nonnative::GRPCServer
+      def initialize(service)
+        super([Greeter.new, HealthService.new], service)
+      end
+    end
+  end
+end
+```
+
+The existing single-handler form remains supported. Nonnative registers each handler before the
+server starts, so application and standard health handlers can share one lifecycle and endpoint.
 
 Set it up programmatically:
 

--- a/features/servers.feature
+++ b/features/servers.feature
@@ -23,6 +23,19 @@ Feature: Servers
     When I send a message with the HTTP client to the servers
     Then I should receive an HTTP "Hello World!" response
 
+  Scenario: HTTP servers compose mounted services
+    Given I configure the system programmatically with a composed HTTP server
+    And I start the system
+    When I send a root message with the HTTP client to the server
+    Then I should receive an HTTP "Hello World!" response
+    When I send a mounted message with the HTTP client to the server
+    Then I should receive an HTTP "Mounted World!" response
+
+  Scenario: HTTP servers reject empty mount maps
+    Given I configure the system programmatically with an empty HTTP server
+    When I attempt to start the system
+    Then starting the system should raise an error containing "HTTP server requires at least one service mount"
+
   Scenario: HTTP servers return not found for unknown routes
     Given I configure the system programmatically with servers
     And I start the system
@@ -40,6 +53,18 @@ Feature: Servers
     And I start the system
     When I send a message with the gRPC client to the servers
     Then I should receive a gRPC "Hello World!" response
+
+  Scenario: gRPC servers compose application and health handlers
+    Given I configure the system programmatically with a composed gRPC server
+    And I start the system
+    When I send a message with the gRPC client to the server
+    Then I should receive a gRPC "Hello World!" response
+    And the gRPC health helper should report "test" serving on port 9002
+
+  Scenario: gRPC servers reject empty handler lists
+    Given I configure the system programmatically with an empty gRPC server
+    When I attempt to start the system
+    Then starting the system should raise an error containing "gRPC server requires at least one service handler"
 
   Scenario: The health endpoint reports the servers as healthy
     Given I configure the system programmatically with servers

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -25,6 +25,34 @@ Given('I configure the system programmatically with servers') do
   end
 end
 
+Given('I configure the system programmatically with a composed HTTP server') do
+  configure_with_defaults(url: 'http://localhost:4567') do |config|
+    add_server(config, name: 'http_server_1', klass: Nonnative::Features::ComposedHTTPServer, timeout: 1,
+                       host: '127.0.0.1', ports: [4567], log: 'test/reports/composed_http_server.log')
+  end
+end
+
+Given('I configure the system programmatically with an empty HTTP server') do
+  configure_with_defaults(url: 'http://localhost:4567') do |config|
+    add_server(config, name: 'http_server_1', klass: Nonnative::Features::EmptyHTTPServer, timeout: 1,
+                       host: '127.0.0.1', ports: [4567], log: 'test/reports/empty_http_server.log')
+  end
+end
+
+Given('I configure the system programmatically with a composed gRPC server') do
+  configure_with_defaults do |config|
+    add_server(config, name: 'grpc_server_1', klass: Nonnative::Features::ComposedGRPCServer, timeout: 1,
+                       host: '127.0.0.1', ports: [9002], log: 'test/reports/composed_grpc_server.log')
+  end
+end
+
+Given('I configure the system programmatically with an empty gRPC server') do
+  configure_with_defaults do |config|
+    add_server(config, name: 'grpc_server_1', klass: Nonnative::Features::EmptyGRPCServer, timeout: 1,
+                       host: '127.0.0.1', ports: [9002], log: 'test/reports/empty_grpc_server.log')
+  end
+end
+
 Given('I configure the system through configuration with servers') do
   load_configuration('features/configs/servers.yml')
 end
@@ -50,10 +78,22 @@ When('I send a message with the HTTP client to the servers') do
   end
 end
 
+When('I send a mounted message with the HTTP client to the server') do
+  @responses = [http_client_for_server('http_server_1').mounted_get]
+end
+
+When('I send a root message with the HTTP client to the server') do
+  @responses = [http_client_for_server('http_server_1').hello_get]
+end
+
 When('I send a message with the gRPC client to the servers') do
   @responses = %w[grpc_server_1 grpc_server_2].map do |name|
     grpc_client_for_server(name).say_hello(greeter_request)
   end
+end
+
+When('I send a message with the gRPC client to the server') do
+  @responses = [grpc_client_for_server('grpc_server_1').say_hello(greeter_request)]
 end
 
 When('I send a {string} request') do |name|

--- a/features/support/grpc_server.rb
+++ b/features/support/grpc_server.rb
@@ -9,5 +9,23 @@ module Nonnative
         super(Greeter.new, service)
       end
     end
+
+    class ComposedGRPCServer < Nonnative::GRPCServer
+      def initialize(service)
+        super([Greeter.new, HealthService.new], service)
+      end
+    end
+
+    class EmptyGRPCServer < Nonnative::GRPCServer
+      def initialize(service)
+        super([], service)
+      end
+    end
+
+    class HealthService < Grpc::Health::V1::Health::Service
+      def check(_request, _call)
+        Grpc::Health::V1::HealthCheckResponse.new(status: :SERVING)
+      end
+    end
   end
 end

--- a/features/support/http_client.rb
+++ b/features/support/http_client.rb
@@ -11,6 +11,12 @@ module Nonnative
         end
       end
 
+      def mounted_get
+        with_retry(1, 1) do
+          get('mounted/hello', { headers: { content_type: :json, accept: :json }, read_timeout: 1, open_timeout: 1 })
+        end
+      end
+
       def hello_post
         with_retry(1, 1) do
           headers = Nonnative::Header.auth_basic('test:test').merge({ content_type: :json, accept: :json })

--- a/features/support/http_server.rb
+++ b/features/support/http_server.rb
@@ -8,6 +8,24 @@ module Nonnative
       end
     end
 
+    class ComposedHTTPServer < Nonnative::HTTPServer
+      def initialize(service)
+        super({ '/mounted' => MountedService.new, '/' => Service.new }, service)
+      end
+    end
+
+    class EmptyHTTPServer < Nonnative::HTTPServer
+      def initialize(service)
+        super({}, service)
+      end
+    end
+
+    class MountedService < Nonnative::HTTPService
+      get '/hello' do
+        'Mounted World!'.to_json
+      end
+    end
+
     class Service < Nonnative::HTTPService
       class << self
         attr_accessor :health_body, :health_status

--- a/lib/nonnative/grpc_server.rb
+++ b/lib/nonnative/grpc_server.rb
@@ -12,13 +12,18 @@ module Nonnative
   #
   # @see Nonnative::Server
   class GRPCServer < Nonnative::Server
-    # Creates a gRPC server and registers the provided service handler.
+    # Creates a gRPC server and registers the provided service handler(s).
     #
-    # @param svc [Object] a gRPC service implementation (typically a `...::Service` subclass instance)
+    # @param svc [Object, Array<Object>] a gRPC service implementation or a non-empty array of
+    #   implementations (typically `...::Service` subclasses or instances)
     # @param service [Nonnative::ConfigurationServer] server configuration
+    # @raise [ArgumentError] if `svc` is an empty array
     def initialize(svc, service)
       @server = GRPC::RpcServer.new
-      server.handle(svc)
+      handlers = svc.is_a?(Array) ? svc : [svc]
+      raise ArgumentError, 'gRPC server requires at least one service handler' if handlers.empty?
+
+      handlers.each { |handler| server.handle(handler) }
 
       # Unfortunately gRPC has only one logger so the first server wins.
       GRPC.define_singleton_method(:logger) do

--- a/lib/nonnative/http_server.rb
+++ b/lib/nonnative/http_server.rb
@@ -36,9 +36,16 @@ module Nonnative
   class HTTPServer < Nonnative::Server
     # Creates a Puma server for the given HTTP service and runner configuration.
     #
-    # @param http_service [#call] an HTTP service instance
+    # @param http_service [#call, Hash<String, #call>] an HTTP service instance or mount map
     # @param service [Nonnative::ConfigurationServer] server configuration
+    # @raise [ArgumentError] if `http_service` is an empty mount map
     def initialize(http_service, service)
+      if http_service.is_a?(Hash)
+        raise ArgumentError, 'HTTP server requires at least one service mount' if http_service.empty?
+
+        http_service = Rack::URLMap.new(http_service)
+      end
+
       # Keep the log IO so the server lifecycle can release Puma's file handle on stop.
       @log = File.open(service.log, 'a')
       options = {

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.23.0'
+  VERSION = '3.24.0'
 end


### PR DESCRIPTION
## What

- Add first-class HTTP mount maps and gRPC handler arrays to the existing in-process server runners.
- Preserve single-app and single-handler constructors, one managed lifecycle, and existing startup/shutdown behavior.
- Reject empty HTTP mount maps and empty gRPC handler lists with clear argument errors.
- Add acceptance scenarios for mounted/root HTTP apps, application plus health gRPC handlers, and empty-input validation.
- Document the new forms and their lifecycle, mount-path, and handler-list contracts in the README.

## Why

- Service authors can host multiple test doubles and health handlers on one managed endpoint without manually bypassing Nonnative with `Rack::URLMap` or a raw `GRPC::RpcServer`.
- The additive API keeps existing downstream single-service subclasses working while making the common multi-service composition workflow explicit and discoverable.

## Testing

- `make features feature=features/servers.feature` - passed: 18 scenarios, 70 steps.
- `make features` - passed: 123 scenarios, 425 steps.
- `make benchmarks` - passed: 7 scenarios, 27 steps.
- `make lint` - passed: 94 files, no offenses.
- `make sec` - passed: no dependency vulnerabilities detected.
- `git diff --check` - passed.
- `AI-assisted-by: [Codex](https://openai.com/codex/)`
