### PR TITLE
feat(proxy): preserve safe upstream response metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.24.0)
+    nonnative (3.25.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/README.md
+++ b/README.md
@@ -541,6 +541,8 @@ end
 
 The system allows you to define an in-process HTTP forward proxy server for external systems, e.g. `api.github.com`. This is a server implementation, not a fault-injection service proxy.
 
+The proxy preserves the upstream status, body, and safe end-to-end response headers such as `Content-Type`, `ETag`, and application-specific metadata. It removes hop-by-hop, connection-nominated, proxy-authentication, and framing headers; `Set-Cookie`, `Location`, and `Content-Encoding` are not forwarded.
+
 Define your server:
 
 ```ruby

--- a/features/http_proxies.feature
+++ b/features/http_proxies.feature
@@ -21,6 +21,12 @@ Feature: HTTP proxies
     When I send a "POST" request with proxy credentials to the local HTTP proxy server
     Then I should receive request details without proxy credentials from the local HTTP proxy server
 
+  Scenario: The local HTTP proxy preserves safe upstream response headers
+    Given I configure the system programmatically with a local HTTP proxy server
+    And I start the system
+    When I request response metadata through the local HTTP proxy server
+    Then I should receive preserved response metadata from the local HTTP proxy server
+
   @config
   Scenario Outline: The configured HTTP proxy returns a <kind> response
     Given I configure the system through configuration with servers

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -155,6 +155,10 @@ When('I send a {string} request with proxy credentials to the local HTTP proxy s
   @response = http_client_for_server('local_http_proxy_server').inspect_request_with_proxy_credentials(verb.downcase)
 end
 
+When('I request response metadata through the local HTTP proxy server') do
+  @response = http_client_for_server('local_http_proxy_server').response_metadata
+end
+
 Then('I should receive an HTTP {string} response') do |response|
   @responses.each do |r|
     expect(r.code).to eq(200)
@@ -203,6 +207,18 @@ Then('I should receive request details without proxy credentials from the local 
   expect(@response.code).to eq(200)
   expect(body['authorization']).to eq('Bearer app-token')
   expect(body['proxy_authorization']).to be_nil
+end
+
+Then('I should receive preserved response metadata from the local HTTP proxy server') do
+  expect(@error).to be_nil
+  expect(@response.code).to eq(201)
+  expect(@response.body).to eq('upstream response body')
+  expect(@response.headers[:content_type]).to eq('application/problem+json')
+  expect(@response.headers[:etag]).to eq('"response-v1"')
+  expect(@response.headers[:x_end_to_end]).to eq('preserved')
+  expect(@response.headers[:www_authenticate]).to eq('Bearer realm="response-test"')
+  expect(@response.headers[:proxy_authenticate]).to be_nil
+  expect(@response.headers[:x_upstream_only]).to be_nil
 end
 
 Then('I should find the server runner {string}') do |name|

--- a/features/support/http_client.rb
+++ b/features/support/http_client.rb
@@ -11,6 +11,12 @@ module Nonnative
         end
       end
 
+      def response_metadata
+        with_retry(1, 1) do
+          get('response-metadata', { read_timeout: 1, open_timeout: 1 })
+        end
+      end
+
       def mounted_get
         with_retry(1, 1) do
           get('mounted/hello', { headers: { content_type: :json, accept: :json }, read_timeout: 1, open_timeout: 1 })

--- a/features/support/http_server.rb
+++ b/features/support/http_server.rb
@@ -72,6 +72,20 @@ module Nonnative
         'Hello World!'.to_json
       end
 
+      get '/response-metadata' do
+        headers(
+          'Content-Type' => 'application/problem+json',
+          'ETag' => '"response-v1"',
+          'X-End-To-End' => 'preserved',
+          'WWW-Authenticate' => 'Bearer realm="response-test"',
+          'Proxy-Authenticate' => 'Basic realm="proxy"',
+          'Connection' => 'X-Upstream-Only',
+          'X-Upstream-Only' => 'not-forwarded'
+        )
+        status 201
+        'upstream response body'
+      end
+
       post '/inspect' do
         inspect_request.to_json
       end

--- a/lib/nonnative/http_proxy_server.rb
+++ b/lib/nonnative/http_proxy_server.rb
@@ -3,7 +3,8 @@
 # Sinatra-based HTTP forward proxy server used as an in-process Nonnative server.
 #
 # The proxy receives inbound HTTP requests and forwards them to an upstream host over HTTPS, returning
-# the upstream response status and body.
+# the upstream response status, body, and safe end-to-end response headers. Hop-by-hop,
+# connection-nominated, proxy-authentication, framing, and deferred response headers are not forwarded.
 #
 # This file defines two classes:
 #
@@ -23,7 +24,25 @@ module Nonnative
   #
   # Supported HTTP verbs: GET, POST, PUT, PATCH, DELETE.
   class HTTPProxy < Nonnative::HTTPService
-    NON_FORWARDABLE_HEADERS = %w[
+    NON_FORWARDABLE_RESPONSE_HEADERS = %w[
+      connection
+      content-encoding
+      content-length
+      keep-alive
+      location
+      proxy-authenticate
+      proxy-authorization
+      proxy-authentication-info
+      proxy-connection
+      set-cookie
+      status
+      te
+      trailer
+      transfer-encoding
+      upgrade
+    ].freeze
+
+    NON_FORWARDABLE_REQUEST_HEADERS = %w[
       Host
       Accept-Encoding
       Version
@@ -37,14 +56,14 @@ module Nonnative
     #
     # @param request [Sinatra::Request] the incoming request
     # @return [Hash{String=>String}] headers to forward to the upstream
-    def retrieve_headers(request)
+    def forward_request_headers(request)
       headers = request.env.each_with_object({}) do |(header, value), result|
-        next unless forward_header?(header)
+        next unless forward_request_header?(header)
 
-        result[normalized_header_name(header)] = value
+        result[normalized_request_header_name(header)] = value
       end
 
-      headers.except(*NON_FORWARDABLE_HEADERS)
+      headers.except(*NON_FORWARDABLE_REQUEST_HEADERS)
     end
 
     # Builds the upstream URL for the given request.
@@ -86,11 +105,43 @@ module Nonnative
 
     private
 
-    def forward_header?(header)
+    def forward_response_headers(response)
+      raw_headers = response.raw_headers
+      connection_headers = response_connection_headers(raw_headers)
+
+      raw_headers.each_with_object({}) do |(header, value), result|
+        normalized_header = normalized_response_header_name(header)
+        next unless forward_response_header?(normalized_header, connection_headers)
+
+        result[normalized_header] = Array(value).join(', ')
+      end
+    end
+
+    def response_connection_headers(raw_headers)
+      connection_headers = raw_headers.each_with_object([]) do |(header, values), result|
+        next unless normalized_response_header_name(header) == 'connection'
+
+        Array(values).each { |value| result.concat(value.to_s.split(',')) }
+      end
+
+      connection_headers.map { |header| normalized_response_header_name(header) }
+    end
+
+    def forward_response_header?(header, connection_headers)
+      !NON_FORWARDABLE_RESPONSE_HEADERS.include?(header) &&
+        !connection_headers.include?(header) &&
+        !header.start_with?('rack.')
+    end
+
+    def normalized_response_header_name(header)
+      header.to_s.strip.downcase
+    end
+
+    def forward_request_header?(header)
       header.start_with?('HTTP_') || %w[CONTENT_TYPE CONTENT_LENGTH].include?(header)
     end
 
-    def normalized_header_name(header)
+    def normalized_request_header_name(header)
       header.delete_prefix('HTTP_').split('_').map(&:capitalize).join('-')
     end
 
@@ -99,10 +150,11 @@ module Nonnative
         res = api_response(
           method: verb.to_sym,
           url: build_url(request, settings),
-          headers: retrieve_headers(request),
+          headers: forward_request_headers(request),
           payload: retrieve_payload(request, verb)
         )
 
+        headers(forward_response_headers(res))
         status res.code
         res.body
       end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.24.0'
+  VERSION = '3.25.0'
 end


### PR DESCRIPTION
## What

- Preserve safe upstream HTTP response metadata through the in-process forward proxy, including status, body, content type, entity tags, authentication challenges, and application-specific headers.
- Filter hop-by-hop, connection-nominated, proxy-authentication, framing, and deferred headers before applying upstream metadata to the downstream response.
- Add Cucumber coverage and document the forwarding and filtering behavior. Align request-side forwarding constant and helper names with the response-side vocabulary; legacy names are intentionally not retained.

## Why

- Clients under test often make decisions from response headers, so forwarding only status and body leaves common HTTP behavior untestable through the documented proxy workflow.
- Filtering at the proxy boundary prevents upstream transport and proxy-control metadata from being exposed or allowing Rack to manage response framing incorrectly.

## Testing

- `make features feature=features/http_proxies.feature tags='not @config'` - passed (6 scenarios, 24 steps).
- `make features` - passed (124 scenarios, 429 steps; 99.27% line coverage).
- `make benchmarks` - passed (7 scenarios, 27 steps; 99.6% line coverage).
- `make lint` - passed (94 files, no offenses).
- `make sec` - passed (0 vulnerabilities detected in `Gemfile.lock`).
- `git diff --check` and Ruby syntax checks - passed.
- The focused scenario verifies preserved safe metadata and representative proxy/connection filtering. It does not enumerate every excluded header or duplicate-header combination.
