### PR TITLE
feat(http): support head and options requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.26.0)
+    nonnative (3.27.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/features/http_proxies.feature
+++ b/features/http_proxies.feature
@@ -27,6 +27,18 @@ Feature: HTTP proxies
     When I request response metadata through the local HTTP proxy server
     Then I should receive preserved response metadata from the local HTTP proxy server
 
+  Scenario: The local HTTP proxy forwards HEAD requests as HEAD
+    Given I configure the system programmatically with a local HTTP proxy server
+    And I start the system
+    When I send a HEAD request to the local HTTP proxy server
+    Then I should receive a successful response from the local HTTP proxy server
+
+  Scenario: The local HTTP proxy preserves safe upstream response headers for OPTIONS requests
+    Given I configure the system programmatically with a local HTTP proxy server
+    And I start the system
+    When I request response metadata with an OPTIONS request through the local HTTP proxy server
+    Then I should receive preserved response metadata from the local HTTP proxy server
+
   @config
   Scenario Outline: The configured HTTP proxy returns a <kind> response
     Given I configure the system through configuration with servers

--- a/features/servers.feature
+++ b/features/servers.feature
@@ -23,6 +23,14 @@ Feature: Servers
     When I send a message with the HTTP client to the servers
     Then I should receive an HTTP "Hello World!" response
 
+  Scenario: HTTP client supports HEAD and OPTIONS requests
+    Given I configure the system programmatically with servers
+    And I start the system
+    When I send a HEAD message with the HTTP client to the server
+    Then I should receive an HTTP response with an empty body and status 200
+    When I send an OPTIONS message with the HTTP client to the server
+    Then I should receive an HTTP response with an empty body and status 200
+
   Scenario: HTTP servers compose mounted services
     Given I configure the system programmatically with a composed HTTP server
     And I start the system

--- a/features/step_definitions/servers_steps.rb
+++ b/features/step_definitions/servers_steps.rb
@@ -159,11 +159,32 @@ When('I request response metadata through the local HTTP proxy server') do
   @response = http_client_for_server('local_http_proxy_server').response_metadata
 end
 
+When('I request response metadata with an OPTIONS request through the local HTTP proxy server') do
+  @response = http_client_for_server('local_http_proxy_server').response_metadata_options
+end
+
+When('I send a HEAD request to the local HTTP proxy server') do
+  @response = http_client_for_server('local_http_proxy_server').inspect_head
+end
+
+When('I send a HEAD message with the HTTP client to the server') do
+  @response = http_client_for_server('http_server_1').hello_head
+end
+
+When('I send an OPTIONS message with the HTTP client to the server') do
+  @response = http_client_for_server('http_server_1').hello_options
+end
+
 Then('I should receive an HTTP {string} response') do |response|
   @responses.each do |r|
     expect(r.code).to eq(200)
     expect(r.body).to eq(response.to_json)
   end
+end
+
+Then('I should receive an HTTP response with an empty body and status {int}') do |status|
+  expect(@response.code).to eq(status)
+  expect(@response.body).to be_nil.or eq('')
 end
 
 Then('I should receive a gRPC {string} response') do |response|
@@ -190,6 +211,11 @@ end
 Then('I should receive a not found response from the HTTP proxy server') do
   expect(@error).to be_nil
   expect(@response.code).to eq(404)
+end
+
+Then('I should receive a successful response from the local HTTP proxy server') do
+  expect(@error).to be_nil
+  expect(@response.code).to eq(200)
 end
 
 Then('I should receive the {string} request details from the local HTTP proxy server') do |verb|

--- a/features/support/http_client.rb
+++ b/features/support/http_client.rb
@@ -59,6 +59,30 @@ module Nonnative
         end
       end
 
+      def hello_head
+        with_retry(1, 1) do
+          head('hello', { read_timeout: 1, open_timeout: 1 })
+        end
+      end
+
+      def hello_options
+        with_retry(1, 1) do
+          options('hello', { read_timeout: 1, open_timeout: 1 })
+        end
+      end
+
+      def inspect_head
+        with_retry(1, 1) do
+          head('inspect', { read_timeout: 1, open_timeout: 1 })
+        end
+      end
+
+      def response_metadata_options
+        with_retry(1, 1) do
+          options('response-metadata', { read_timeout: 1, open_timeout: 1 })
+        end
+      end
+
       def inspect_request(verb, body)
         with_retry(1, 1) do
           headers = inspect_headers(verb)

--- a/features/support/http_server.rb
+++ b/features/support/http_server.rb
@@ -50,6 +50,20 @@ module Nonnative
             user_agent: request.env['HTTP_USER_AGENT']
           }
         end
+
+        def preserved_metadata_response
+          headers(
+            'Content-Type' => 'application/problem+json',
+            'ETag' => '"response-v1"',
+            'X-End-To-End' => 'preserved',
+            'WWW-Authenticate' => 'Bearer realm="response-test"',
+            'Proxy-Authenticate' => 'Basic realm="proxy"',
+            'Connection' => 'X-Upstream-Only',
+            'X-Upstream-Only' => 'not-forwarded'
+          )
+          status 201
+          'upstream response body'
+        end
       end
 
       get '/hello' do
@@ -72,18 +86,16 @@ module Nonnative
         'Hello World!'.to_json
       end
 
+      options '/hello' do
+        status 200
+      end
+
       get '/response-metadata' do
-        headers(
-          'Content-Type' => 'application/problem+json',
-          'ETag' => '"response-v1"',
-          'X-End-To-End' => 'preserved',
-          'WWW-Authenticate' => 'Bearer realm="response-test"',
-          'Proxy-Authenticate' => 'Basic realm="proxy"',
-          'Connection' => 'X-Upstream-Only',
-          'X-Upstream-Only' => 'not-forwarded'
-        )
-        status 201
-        'upstream response body'
+        preserved_metadata_response
+      end
+
+      options '/response-metadata' do
+        preserved_metadata_response
       end
 
       post '/inspect' do
@@ -100,6 +112,10 @@ module Nonnative
 
       delete '/inspect' do
         inspect_request.to_json
+      end
+
+      head '/inspect' do
+        status 200
       end
 
       get '/test/healthz' do

--- a/lib/nonnative/http_client.rb
+++ b/lib/nonnative/http_client.rb
@@ -92,18 +92,44 @@ module Nonnative
       end
     end
 
+    # Performs a HEAD request.
+    #
+    # @param pathname [String] path relative to `host`
+    # @param opts [Hash] RestClient request options (e.g. `headers`, `read_timeout`, `open_timeout`)
+    # @return [RestClient::Response, String] response for non-2xx errors, otherwise the RestClient result
+    def head(pathname, opts = {})
+      with_exception do
+        resource(pathname, opts).head
+      end
+    end
+
+    # Performs an OPTIONS request.
+    #
+    # @param pathname [String] path relative to `host`
+    # @param opts [Hash] RestClient request options (e.g. `headers`, `read_timeout`, `open_timeout`)
+    # @return [RestClient::Response, String] response for non-2xx errors, otherwise the RestClient result
+    def options(pathname, opts = {})
+      with_exception do
+        RestClient::Request.execute(opts.merge(method: :options, url: request_url(pathname)))
+      end
+    end
+
     # Creates a RestClient resource for a relative path.
     #
     # @param pathname [String] path relative to `host`
     # @param opts [Hash] RestClient request options
     # @return [RestClient::Resource]
     def resource(pathname, opts)
-      RestClient::Resource.new(URI.join(host, pathname).to_s, opts)
+      RestClient::Resource.new(request_url(pathname), opts)
     end
 
     private
 
     attr_reader :host, :exceptions
+
+    def request_url(pathname)
+      URI.join(host, pathname).to_s
+    end
 
     def with_exception
       yield

--- a/lib/nonnative/http_proxy_server.rb
+++ b/lib/nonnative/http_proxy_server.rb
@@ -22,7 +22,7 @@ module Nonnative
   #
   # The upstream host is configured via service settings (see {Nonnative::HTTPProxyServer}).
   #
-  # Supported HTTP verbs: GET, POST, PUT, PATCH, DELETE.
+  # Supported HTTP verbs: GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS.
   class HTTPProxy < Nonnative::HTTPService
     NON_FORWARDABLE_RESPONSE_HEADERS = %w[
       connection
@@ -145,7 +145,16 @@ module Nonnative
       header.delete_prefix('HTTP_').split('_').map(&:capitalize).join('-')
     end
 
-    %w[get post put patch delete].each do |verb|
+    # Registered before `get` so it takes precedence over Sinatra's GET-generated HEAD route,
+    # which would otherwise forward HEAD requests upstream as GET.
+    head(/.*/) do
+      res = api_response(method: :head, url: build_url(request, settings), headers: forward_request_headers(request))
+
+      headers(forward_response_headers(res))
+      status res.code
+    end
+
+    %w[get post put patch delete options].each do |verb|
       send(verb, /.*/) do
         res = api_response(
           method: verb.to_sym,

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.26.0'
+  VERSION = '3.27.0'
 end


### PR DESCRIPTION
## What

- Added protected `head(pathname, opts = {})` and `options(pathname, opts = {})` helpers to `Nonnative::HTTPClient`, matching the existing per-verb helper shape (`get`/`post`/`put`/`patch`/`delete`).
- Fixed `Nonnative::HTTPProxy` to forward HEAD and OPTIONS requests unmodified: an explicit HEAD route is registered ahead of Sinatra's GET-generated HEAD route (which previously silently forwarded HEAD upstream as GET), and OPTIONS is now part of the existing verb-forwarding loop instead of 404ing locally.
- OPTIONS requests through the proxy remain intentionally bodyless (matches typical capability/CORS-preflight usage); all previously supported verbs (GET/POST/PUT/PATCH/DELETE) are unchanged.

## Why

- HEAD/OPTIONS are common metadata-probe and CORS-preflight verbs. Nonnative's HTTP client extension surface documents a per-verb helper shape for the other five verbs but omitted these two, forcing consumers to drop below that surface and reimplement the client's exception/retry plumbing.
- The proxy silently rewriting HEAD to GET can execute the wrong upstream handler, and rejecting OPTIONS outright blocks standard preflight/capability workflows, both of which make dependency behavior for these verbs untestable through Nonnative.

## Testing

- `make features feature=features/http_proxies.feature` - passed (10/10 scenarios), adding proxy-level scenarios that prove HEAD reaches upstream as HEAD (not GET) and OPTIONS preserves upstream status/headers.
- `make features feature=features/servers.feature` - passed (19/19 scenarios), adding a direct-client scenario that proves `HTTPClient#head`/`#options` work against a real server.
- `make features` - passed (127/127; one `features/lifecycle.feature` scenario flaked once under full-suite load from port reuse, a documented repository caveat — reproduced a clean pass on immediate rerun and confirmed absent on an unmodified-HEAD run).
- `make benchmarks` - passed (8/8).
- `make lint` - passed (94 files, no offenses).
- `make sec` - passed (0 vulnerabilities).
- Scoped gap: sending an OPTIONS request with a body through the proxy is untested. The proxy intentionally treats OPTIONS as bodyless (any client body is dropped rather than forwarded), matching real-world OPTIONS usage.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
