### PR TITLE
feat(pool): report server thread termination detail in start errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,13 @@ of dependencies.
   unless the task is explicitly about changing the `Nonnative::Service`
   readiness model. HTTP/gRPC readiness belongs to managed processes, where the
   user explicitly models the application health endpoints.
+- Multiple managed processes remain supported, but the pool's service -> server
+  -> process startup order is the intentional dependency model: typical suites
+  manage one system process and model its dependencies as externally managed
+  services or in-process servers, which become ready first. Do not flag the
+  absence of process-to-process `depends_on`, dependency graphs, or topological
+  process startup as a feature gap unless downstream usage evidence exists or
+  the task is explicitly about changing the lifecycle model.
 - Managed-process readiness intentionally supports only TCP-port-open plus the
   optional `http`/`grpc` health probes in `Nonnative::ConfigurationReadiness`.
   A log-line/log-message readiness kind (`kind: 'log'`) is intentionally not

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nonnative (3.28.0)
+    nonnative (3.29.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)

--- a/features/benchmark.feature
+++ b/features/benchmark.feature
@@ -20,6 +20,14 @@ Feature: Benchmark
     When I attempt to start the system
     Then starting the system should raise an error
     And starting the system should raise an error containing "though did not respond in time"
+    And starting the system should raise an error containing "server thread exited before readiness"
+
+  @manual
+  Scenario: Start nonnative with a server that raises before readiness reports the exception
+    Given I configure the system programmatically with a server that raises before readiness
+    When I attempt to start the system
+    Then starting the system should raise an error
+    And starting the system should raise an error containing "StandardError: boom on perform_start"
 
   @manual
   Scenario: Start nonnative with a start error will rollback started runners

--- a/features/step_definitions/benchmark_steps.rb
+++ b/features/step_definitions/benchmark_steps.rb
@@ -6,6 +6,12 @@ Given('I configure the system programmatically with a no op server') do
   end
 end
 
+Given('I configure the system programmatically with a server that raises before readiness') do
+  configure_with_defaults do |config|
+    add_server(config, klass: Nonnative::Features::RaiseStartServer, timeout: 1, ports: [14_008])
+  end
+end
+
 Given('I configure the system programmatically with a no stop server') do
   configure_with_defaults do |config|
     add_server(config, klass: Nonnative::Features::NoStopServer, timeout: 1, ports: [14_001])

--- a/features/support/raise_start_server.rb
+++ b/features/support/raise_start_server.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Nonnative
+  module Features
+    class RaiseStartServer < Nonnative::Server
+      def perform_start
+        raise StandardError, 'boom on perform_start'
+      end
+
+      def perform_stop
+        # Do nothing
+      end
+    end
+  end
+end

--- a/lib/nonnative/server.rb
+++ b/lib/nonnative/server.rb
@@ -32,7 +32,14 @@ module Nonnative
     #   - `true` (thread creation itself is considered started; readiness is checked separately)
     def start
       unless thread
-        @thread = Thread.new { perform_start }
+        @error = nil
+        @thread = Thread.new do
+          perform_start
+        rescue StandardError => e
+          @error = e
+          raise
+        end
+        @thread.report_on_exception = true
 
         wait_start
 
@@ -61,8 +68,22 @@ module Nonnative
       object_id
     end
 
+    # Describes how the server thread terminated before becoming ready, for lifecycle diagnostics.
+    #
+    # Returns `nil` while the thread is still alive, so callers can distinguish a dead thread from a
+    # live server that merely missed its readiness window.
+    #
+    # @return [String, nil] termination detail (clean early return or uncaught exception), or `nil`
+    def termination
+      return if thread.nil? || thread.alive?
+
+      return "server thread raised #{error.class}: #{error.message}" if error
+
+      'server thread exited before readiness'
+    end
+
     private
 
-    attr_reader :thread, :timeout
+    attr_reader :thread, :timeout, :error
   end
 end

--- a/lib/nonnative/version.rb
+++ b/lib/nonnative/version.rb
@@ -4,5 +4,5 @@ module Nonnative
   # The current gem version.
   #
   # @return [String]
-  VERSION = '3.28.0'
+  VERSION = '3.29.0'
 end


### PR DESCRIPTION
## What

- When an in-process `Server` thread returns early or raises before its port becomes ready, `Nonnative::StartError` now names that the thread ended and, for an uncaught exception, its class and message. Previously only the generic "did not respond in time" message was shown, with no way to tell a dead thread from a genuinely slow one.
- `Server` pins `Thread#report_on_exception = true` on the thread it creates, so the exception backtrace is still printed to stderr regardless of any ambient global default already set elsewhere in the host process.
- Adds an `AGENTS.md` note documenting an existing intentional design choice: the pool's service -> server -> process startup order, and that process-to-process `depends_on`/topological startup is out of scope absent downstream usage evidence.

## Why

- Custom in-process servers are a documented extension point. A dead server thread and a live server that merely missed its readiness window used to produce an identical error, forcing service authors to guess or correlate separate stderr output to tell them apart.
- This mirrors the existing `Process#termination` diagnostic pattern (used for OS processes) so both runner types report equivalent startup-failure detail through the same `StartError`.

## Testing

- `make benchmarks feature=features/benchmark.feature` - passed (9 scenarios, 38 steps), including one extended and one new scenario covering a clean early return and an uncaught `perform_start` exception.
- `make features` - passed (129 scenarios, 456 steps).
- `make lint` - passed (96 files, no offenses).
- Reviewed the diff for thread-safety: `@error` is always set before the thread dies (so no read-before-write race with `termination`), and `termination` is only read from the start path, never overlapping with `stop`'s `thread.terminate`.
