### PR TITLE
docs(readme): align readiness rdoc with probe behavior and document the bandwidth rate option

### DIFF
--- a/lib/nonnative.rb
+++ b/lib/nonnative.rb
@@ -265,7 +265,8 @@ module Nonnative
 
     # Starts all configured services, servers, and processes, and waits for readiness.
     #
-    # Readiness is determined by attempting to connect to each runner's configured host/ports.
+    # Readiness is determined by port checks, plus optional process HTTP/gRPC readiness and optional
+    # service TCP readiness.
     #
     # @return [void]
     # @raise [Nonnative::StartError] if one or more runners fail to start or become ready in time

--- a/lib/nonnative/fault_injection_proxy.rb
+++ b/lib/nonnative/fault_injection_proxy.rb
@@ -37,6 +37,8 @@ module Nonnative
   #   - `delay`: delay duration in seconds used by {#delay}
   #   - `jitter`: optional random offset (seconds) added in `-jitter..jitter` to each `delay` (a
   #     negative value uses its magnitude), so clients see variable latency instead of a flat value
+  #   - `rate`: positive throughput limit in KB/s used by {#bandwidth}; absent or non-positive
+  #     values forward at full speed
   #   - `bytes`: positive response byte limit used by {#limit_data}; absent or non-positive values
   #     use pass-through behavior
   #

--- a/lib/nonnative/ports.rb
+++ b/lib/nonnative/ports.rb
@@ -3,8 +3,8 @@
 module Nonnative
   # Performs aggregate TCP readiness/shutdown checks for all configured runner ports.
   #
-  # A runner is considered ready only when every configured port is open, and stopped only when every
-  # configured port is closed.
+  # A runner is considered ready only when every configured port is open and every configured
+  # HTTP/gRPC readiness probe reports ready, and stopped only when every configured port is closed.
   #
   # @see Nonnative::Port
   class Ports
@@ -15,7 +15,8 @@ module Nonnative
       @readiness = readiness_probes
     end
 
-    # Returns whether all configured ports become connectable before their timeouts elapse.
+    # Returns whether all configured ports become connectable and all configured HTTP/gRPC readiness
+    # probes report ready before their timeouts elapse.
     #
     # @return [Boolean]
     def open?


### PR DESCRIPTION
## What

- Corrected the `Nonnative.start` and `Nonnative::Ports` RDoc so readiness is described the way it actually behaves: TCP port checks plus optional process HTTP/gRPC readiness probes and optional service TCP readiness. The previous comments described readiness as TCP-port connectivity only.
- Added the missing `rate` key to the `Nonnative::FaultInjectionProxy` class-level `options:` enumeration. It is the KB/s throttle read by `#bandwidth`; it was already documented on the method but absent from the consolidated options list.
- Documentation-comment-only change: no runtime behavior, public method signatures, or configuration surface changed.

## Why

- The `start` and `Ports#open?` comments understated the readiness contract, so a reader relying on them would not realize a configured HTTP/gRPC probe gates startup (and can itself raise `Nonnative::StartError`), and could be confused when `open?` returns false while every TCP port is open. `Ports#closed?` remains ports-only and the wording preserves that.
- The `FaultInjectionProxy` options block reads as the authoritative set of `service.proxy.options` keys, so omitting `rate` could lead a consumer wiring bandwidth throttling to miss the knob they need.
- Found during a repository-wide doc-gap pass. The README and the rest of the code were already accurate, so this closes the remaining in-code contract drift.

## Testing

- `make lint` - passed (RuboCop, 96 files, no offenses).
- No behavior changed (RDoc/comment-only), so no new tests were added; `make features` and `make benchmarks` cover behavior and are unaffected by comment edits. CI runs the full lint/sec/features/benchmarks suite as additional verification.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
